### PR TITLE
Minor updates and fixes to Quickstart, RAG, and TGI notebooks

### DIFF
--- a/PyTorch/Intel_Gaudi_Quickstart/Intel_Gaudi_Quick_Start.ipynb
+++ b/PyTorch/Intel_Gaudi_Quickstart/Intel_Gaudi_Quick_Start.ipynb
@@ -404,7 +404,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Please be sure to run this exit command to ensure that the resorces running on Intel Gaudi are released \n",
+    "# Please be sure to run this exit command to ensure that the resources running on Intel Gaudi are released \n",
     "exit()"
    ]
   }

--- a/PyTorch/Intel_Gaudi_Quickstart/Intel_Gaudi_Quick_Start.ipynb
+++ b/PyTorch/Intel_Gaudi_Quickstart/Intel_Gaudi_Quick_Start.ipynb
@@ -403,7 +403,10 @@
    "id": "2c577b02-bb5a-4cf7-a3cc-f58df42264f1",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Please be sure to run this exit command to ensure that the resorces running on Intel Gaudi are released \n",
+    "exit()"
+   ]
   }
  ],
  "metadata": {

--- a/PyTorch/Profiling_and_Optimization/New_Profiler_and_Optimization.ipynb
+++ b/PyTorch/Profiling_and_Optimization/New_Profiler_and_Optimization.ipynb
@@ -326,7 +326,7 @@
     "### Running the Model\n",
     "Now that the model is loaded, we'll run the model and look for the trace files for analysis. \n",
     "\n",
-    "For this model script we can see the profilig set in the utils.py. \n",
+    "For this model script we can see the profiling set in the utils.py. \n",
     "For other models not in optimum-habana, users can refer to [Profiling_with_PyTorch](https://docs.habana.ai/en/latest/Profiling/Profiling_with_PyTorch.html) to setup profiling "
    ]
   },
@@ -372,9 +372,8 @@
     "\n",
     "Notice the torch profiler specific commands:\n",
     "\n",
-    "--profiling_warmup_steps 10  \n",
-    "- profiler will wait for warmup steps\n",
-    "- --profiling_steps 3 - records for the next active steps  \n",
+    "- `--profiling_warmup_steps 10` - profiler will wait for warmup steps\n",
+    "- `--profiling_steps 3` - records for the next active steps  \n",
     "                             \n",
     "The collected trace files will be saved to ./hpu_profile"
    ]

--- a/PyTorch/RAG_Application/RAG-on-Intel-Gaudi.ipynb
+++ b/PyTorch/RAG_Application/RAG-on-Intel-Gaudi.ipynb
@@ -69,7 +69,7 @@
     "   \n",
     "2. Before you load this Notebook, you will run the standard docker image but you need to include the `/var/run/docker.sock` file.  Use these Run and exec commands below to start your docker. \n",
     "\n",
-    "`docker run -itd --name RAG --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --ipc=host -v /var/run/docker.sock:/var/run/docker.sock  vault.habana.ai/gaudi-docker/1.16.2/ubuntu22.04/habanalabs/pytorch-installer-2.1.2:latest`  \n",
+    "`docker run -itd --name RAG --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --ipc=host -v /var/run/docker.sock:/var/run/docker.sock  vault.habana.ai/gaudi-docker/1.16.2/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest`  \n",
     "\n",
     "`docker exec -it RAG bash`\n",
     "\n",

--- a/PyTorch/Single_card_tutorials/Intel_Gaudi_Quick_Start_single.ipynb
+++ b/PyTorch/Single_card_tutorials/Intel_Gaudi_Quick_Start_single.ipynb
@@ -245,7 +245,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Please be sure to run this exit command to ensure that the resorces running on Intel Gaudi are released \n",
+    "# Please be sure to run this exit command to ensure that the resources running on Intel Gaudi are released \n",
     "exit()"
    ]
   }

--- a/PyTorch/Single_card_tutorials/RAG-on-Intel-Gaudi-single.ipynb
+++ b/PyTorch/Single_card_tutorials/RAG-on-Intel-Gaudi-single.ipynb
@@ -614,7 +614,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Please be sure to run this exit command to ensure that the resorces running on Intel Gaudi are released \n",
+    "# Please be sure to run this exit command to ensure that the resources running on Intel Gaudi are released \n",
     "exit()"
    ]
   },

--- a/PyTorch/Single_card_tutorials/llama2_fine_tuning_inference_single.ipynb
+++ b/PyTorch/Single_card_tutorials/llama2_fine_tuning_inference_single.ipynb
@@ -341,7 +341,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Please be sure to run this exit command to ensure that the resorces running on Intel Gaudi are released \n",
+    "# Please be sure to run this exit command to ensure that the resources running on Intel Gaudi are released \n",
     "exit()"
    ]
   }

--- a/PyTorch/Single_card_tutorials/model_migrate_single.ipynb
+++ b/PyTorch/Single_card_tutorials/model_migrate_single.ipynb
@@ -471,7 +471,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Please be sure to run this exit command to ensure that the resorces running on Intel Gaudi are released \n",
+    "# Please be sure to run this exit command to ensure that the resources running on Intel Gaudi are released \n",
     "exit()"
    ]
   },

--- a/PyTorch/Single_card_tutorials/stable_diffusion_v_2_1_single.ipynb
+++ b/PyTorch/Single_card_tutorials/stable_diffusion_v_2_1_single.ipynb
@@ -216,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Please be sure to run this exit command to ensure that the resorces running on Intel Gaudi are released \n",
+    "# Please be sure to run this exit command to ensure that the resources running on Intel Gaudi are released \n",
     "exit()"
    ]
   },

--- a/PyTorch/TGI_Gaudi_tutorial/TGI_on_Intel_Gaudi.ipynb
+++ b/PyTorch/TGI_Gaudi_tutorial/TGI_on_Intel_Gaudi.ipynb
@@ -94,7 +94,7 @@
    "metadata": {},
    "source": [
     "### 2. Loading the Text Generation Inference (TGI-gaudi) Environment. \n",
-    "we pull the latest TGI-gaudi image.  This image contains the TGI server and launcher that you will access with POST commands"
+    "We pull the latest TGI-gaudi image.  This image contains the TGI server and launcher that you will access with POST commands."
    ]
   },
   {
@@ -115,7 +115,7 @@
     "#### After building image you will run run it:\n",
     "\n",
     "##### How to access and Use the Llama 3 model\n",
-    "To use the Llama 3 model, you will need a HuggingFace account, agree to the terms of use of the model in its model card on the HF Hub, and create a read token.  You then copy that token to the HUGGING_FACE_HUB_TOKEN variable below. \n",
+    "To use the [Llama 3](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct) model, you will need a HuggingFace account, agree to the terms of use of the model in its model card on the HF Hub, and create a read token.  You then copy that token to the HUGGING_FACE_HUB_TOKEN variable below. \n",
     "\n",
     "You will select an LLM model that you wish to use.  In this case, we have selected the Llama 3 8B Instruct model from Meta Labs. This model will fit in one Intel Gaudi   \n",
     "\n",
@@ -160,7 +160,7 @@
     "#### Model Configuration Variables\n",
     "**The Maximum sequence length is controlled by the first two arguments:**  \n",
     "**--max-total-tokens** \n",
-    "This is the most important value to set as it defines the \"memory budget\" of running clients requests. Clients will send input sequences and ask to generate `max_new_tokens` on top. with a value of `1512` users can send either a prompt of `1000` and ask for `512` new tokens, or send a prompt of `1` and ask for `1511` max_new_tokens.  The example above sets the total tokens at 2048\n",
+    "This is the most important value to set as it defines the \"memory budget\" of running clients requests. Clients will send input sequences and ask to generate `max_new_tokens` on top. With a value of `1512` users can send either a prompt of `1000` and ask for `512` new tokens, or send a prompt of `1` and ask for `1511` max_new_tokens.  The example above sets the total tokens at 2048\n",
     "\n",
     "**--max-input-tokens** \n",
     "This is the maximum allowed input length (expressed in number of tokens) for users. The larger this value, the longer prompt users can send which can impact the overall memory required to handle the load. Please note that some models have a finite range of sequence they can handle. Default to min(max_position_embeddings - 1, 4095).  For this example, \n",
@@ -175,12 +175,14 @@
     "Enforce a maximum number of requests per batch Specific flag for hardware targets that do not support unpadded inference\n",
     "\n",
     "#### Environment Variables\n",
-    "The settings in the example above are all set to the default values:    \n",
-    "ENABLE_HPU_GRAPH            Enable hpu graph or disable it.  It's recommended to leave this enabled for best performance.   \n",
-    "LIMIT_HPU_GRAPH\tSkip        HPU graph usage for prefill to save memory, set to True for large sequence/decoding lengths  \n",
-    "BATCH_BUCKET_SIZE           Batch size for decode operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs\t  \n",
-    "PREFILL_BATCH_BUCKET_SIZE   Batch size for prefill operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs\t  \n",
-    "PAD_SEQUENCE_TO_MULTIPLE_OF For prefill operation, sequences will be padded to a multiple of provided value.  "
+    "The settings in the example above are all set to the default values.\n",
+    "| Environment Variable | Default | Description |\n",
+    "|----------------------|---------|-------------|    \n",
+    "| `ENABLE_HPU_GRAPH` | True | Enable hpu graph or disable it.  It's recommended to leave this enabled for best performance. |\n",
+    "| `LIMIT_HPU_GRAPH` | False | Skip HPU graph usage for prefill to save memory, set to True for large sequence/decoding lengths. |\n",
+    "| `BATCH_BUCKET_SIZE` | 8 | Batch size for decode operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs. | \n",
+    "| `PREFILL_BATCH_BUCKET_SIZE` | 4 | Batch size for prefill operation will be rounded to the nearest multiple of this number. This limits the number of cached graphs. |\n",
+    "| `PAD_SEQUENCE_TO_MULTIPLE_OF` | 128 | For prefill operation, sequences will be padded to a multiple of provided value. |"
    ]
   },
   {
@@ -402,6 +404,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "07479c69",
+   "metadata": {},
+   "source": [
+    "When you are done running experiments, you can stop the container to free resources that will be used for the performance example in the next section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7613404f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker stop gaudi-tgi\n",
+    "!docker rm gaudi-tgi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c45bcd7d-8bfc-4ce7-8ea9-0176ce07b122",
    "metadata": {},
    "source": [
@@ -462,6 +483,8 @@
    "id": "15df1a0e-21ae-4165-aa3c-62a08fe001fe",
    "metadata": {},
    "source": [
+    "Like the previous example, open a separate terminal window and use `docker logs gaudi-tgi-perf` to check the status and wait for the server to be ready.\n",
+    "\n",
     "First, do a quick test to ensure that the TGI-gaudi is working with this new performance configuration:"
    ]
   },
@@ -658,6 +681,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!docker stop gaudi-tgi-perf\n",
+    "!docker rm gaudi-tgi-perf\n",
+    "\n",
     "exit()"
    ]
   }

--- a/PyTorch/Training a Classifier/cifar10_tutorial.ipynb
+++ b/PyTorch/Training a Classifier/cifar10_tutorial.ipynb
@@ -319,7 +319,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See `here <https://pytorch.org/docs/stable/notes/serialization.html>`_\n",
+    "See the [PyTorch documentation on serialization](https://pytorch.org/docs/stable/notes/serialization.html)\n",
     "for more details on saving PyTorch models.\n",
     "\n",
     "5. Test the network on the test data\n",
@@ -347,7 +347,7 @@
     "\n",
     "# print images\n",
     "imshow(torchvision.utils.make_grid(images))\n",
-    "print('GroundTruth: ', ' '.join('%5s' % classes[labels[j]] for j in range(4)))"
+    "print('GroundTruth: ', ' '.join('%5s' % classes[labels[j]] for j in range(batch_size)))"
    ]
   },
   {

--- a/PyTorch/Training a Classifier/cifar10_tutorial.ipynb
+++ b/PyTorch/Training a Classifier/cifar10_tutorial.ipynb
@@ -406,7 +406,7 @@
     "_, predicted = torch.max(outputs, 1)\n",
     "\n",
     "print('Predicted: ', ' '.join('%5s' % classes[predicted[j]]\n",
-    "                              for j in range(4)))"
+    "                              for j in range(batch_size)))"
    ]
   },
   {


### PR DESCRIPTION
This PR has updates to a few of the notebook tutorials based on issues that I ran into when running the notebooks on Intel Tiber Developer Cloud.

Quickstart notebook:
* Adds an `exit()` to the end of the notebook. Other notebooks have the exit, but I noticed this one did not.

New Profiler and Optimization notebook:
* Fixed typo and formatting

RAG Application notebook:
* The name of the docker image was incorrect, so trying to copy/paste the command was causing an error.

Single card tutorials:
* Spelling fix

TGI Gaudi notebook:
* Typos and added a link to the Llama 3 model being used, so that it's easier to find the model and request access.
* Formatted the environment variables with default values and descriptions into a table to make it easier to read.
* Added `docker stop <container name>` and `docker rm <container name>` commands for the tgi-gaudi and tgi-gaudi-perf containers. If the tgi-gaudi container is not stopped, the tgi-gaudi-perf container will get an error about not being able to acquire the device. The perf container should also be stopped when it's done being used, so that the user can move on to run scripts using the Gaudi devices.
* Added a note about waiting for the TGI server to be ready in the performance example section (if you run the next cell too quickly, the curl command will fail)

Training a Classifier CIFAR10 notebook:
* Link formatting
* The notebook says that was adapted from a [pytorch cifar10 tutorial](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html). That PyTorch tutorial happens to use a batch size of 4. This Gaudi tutorial instead uses a batch size of 64, but there were a couple `4`s that are hardcoded in places which was making the number of labels being displayed not match up with the number of images being displayed. I fixed this by changing those `4`s to be `batch_size`.