### PR TITLE
RAG: fix langchain deprecated warning

### DIFF
--- a/PyTorch/RAG_Application/RAG-on-Intel-Gaudi.ipynb
+++ b/PyTorch/RAG_Application/RAG-on-Intel-Gaudi.ipynb
@@ -73,7 +73,10 @@
     "\n",
     "`docker exec -it RAG bash`\n",
     "\n",
-    "`cd ~ && git clone https://github.com/HabanaAI/Gaudi-tutorials`\n"
+    "`cd ~ && git clone https://github.com/HabanaAI/Gaudi-tutorials`\n",
+    "\n",
+    "If you find connectivity issues you can pass proxy information to docker container adding the following to the `docker run` command:\n",
+    "`-e https_proxy=<your_proxy_address> -e HTTP_PROXY=<your_proxy_address> -e no_proxy=\"localhost;127.0.0.1\"`\n"
    ]
   },
   {
@@ -402,7 +405,7 @@
     "from langchain.text_splitter import CharacterTextSplitter\n",
     "from langchain_community.document_loaders import TextLoader\n",
     "from langchain.vectorstores.pgvector import PGVector\n",
-    "from langchain_community.embeddings import HuggingFaceHubEmbeddings"
+    "from langchain_huggingface import HuggingFaceEndpointEmbeddings"
    ]
   },
   {
@@ -421,7 +424,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embeddings = HuggingFaceHubEmbeddings(model=\"http://localhost:9002\", huggingfacehub_api_token=\"EMPTY\")\n",
+    "embeddings = HuggingFaceEndpointEmbeddings(model=\"http://localhost:9002\", huggingfacehub_api_token=\"EMPTY\")\n",
     "store = PGVector(\n",
     "    collection_name=\"documents\",\n",
     "    connection_string=\"postgresql+psycopg2://postgres:postgres@localhost:9003/postgres\",\n",
@@ -491,7 +494,7 @@
    "outputs": [],
    "source": [
     "from langchain.vectorstores.pgvector import PGVector\n",
-    "from langchain.embeddings import HuggingFaceHubEmbeddings\n",
+    "from langchain_huggingface import HuggingFaceEndpointEmbeddings\n",
     "from text_generation import Client\n",
     "\n",
     "rag_prompt_intel_raw = \"\"\"### System: You are an assistant for question-answering tasks. Use the following pieces of retrieved context to answer the question. If you don't know the answer, just say that you don't know. Use three sentences maximum and keep the answer concise. \n",
@@ -503,7 +506,7 @@
     "### Assistant: \"\"\"\n",
     "\n",
     "def get_sources(question):\n",
-    "    embeddings = HuggingFaceHubEmbeddings(model=\"http://localhost:9002\", huggingfacehub_api_token=\"EMPTY\")\n",
+    "    embeddings = HuggingFaceEndpointEmbeddings(model=\"http://localhost:9002\", huggingfacehub_api_token=\"EMPTY\")\n",
     "    store = PGVector(\n",
     "        collection_name=\"documents\",\n",
     "        connection_string=\"postgresql+psycopg2://postgres:postgres@localhost:9003/postgres\",\n",

--- a/PyTorch/RAG_Application/requirements.txt
+++ b/PyTorch/RAG_Application/requirements.txt
@@ -7,6 +7,7 @@ requests
 langchain
 langchain-experimental
 langchain-community
+langchain_huggingface
 text-generation
 pgvector
 gradio

--- a/PyTorch/Single_card_tutorials/model_migrate_single.ipynb
+++ b/PyTorch/Single_card_tutorials/model_migrate_single.ipynb
@@ -21,7 +21,7 @@
    "id": "16169a66",
    "metadata": {},
    "source": [
-    "# Model Migration from GPU to the Intel&reg; Gaudi&reg; 2 AI Processor \n",
+    "# Model Migration from GPU to the Intel&reg; Gaudi&reg; 2 AI Accelerator \n",
     "\n",
     "The GPU Migration toolkit simplifies migrating PyTorch models that run on GPU-based architecture to run on the Intel® Gaudi® AI accelerator. Rather than manually replacing Python API calls that have dependencies on GPU libraries with Gaudi-specific API calls, the toolkit automates this process so you can run your model with fewer modifications.  \n",
     "\n",
@@ -67,7 +67,7 @@
    "id": "64847f32",
    "metadata": {},
    "source": [
-    "#### Naviagte to the model example to begin the run"
+    "#### Navigate to the model example to begin the run"
    ]
   },
   {
@@ -86,7 +86,7 @@
    "metadata": {},
    "source": [
     "#### Download dataset - OPTIONAL\n",
-    "To fully run this example you can downlaod the ImageNet 2012 dataset.  It needs to be organized according to PyTorch requirements, and as specified in the scripts of [imagenet-multiGPU.torch](https://github.com/soumith/imagenet-multiGPU.torch).   You do NOT need to have the dateset loaded to see the Migration steps and logging.    \n",
+    "To fully run this example you can download the ImageNet 2012 dataset.  It needs to be organized according to PyTorch requirements, and as specified in the scripts of [imagenet-multiGPU.torch](https://github.com/soumith/imagenet-multiGPU.torch).   You do NOT need to have the dateset loaded to see the Migration steps and logging.    \n",
     "\n",
     "If you do not download the dataset the training will not complete the execution, but you will see the GPU Migration changes in the logfile."
    ]
@@ -97,7 +97,7 @@
    "metadata": {},
    "source": [
     "#### Import GPU Migration Toolkit package and Habana Torch Library\n",
-    "Look into train.py, you will see in the first line that we will load the `gpu.migration` libary which is already inclucded in the Intel Gaudi Software: "
+    "Look into train.py, you will see in the first line that we will load the `gpu.migration` libary which is already included in the Intel Gaudi Software: "
    ]
   },
   {
@@ -132,7 +132,7 @@
    ],
    "source": [
     "%%sh\n",
-    "cat -n train.py | head -n 20 | tail -n 17"
+    "cat -n train.py | head -n 21 | tail -n 18"
    ]
   },
   {


### PR DESCRIPTION
Huggingface community integrations into langchain are deprecating in favor of langchain-huggingface partner package. This code fixes the error message. 
Added comment in regards to adding proxy env variables to docker run.