### PR TITLE
Fix warnings

### DIFF
--- a/PyTorch/Single_card_tutorials/RAG-on-Intel-Gaudi-single.ipynb
+++ b/PyTorch/Single_card_tutorials/RAG-on-Intel-Gaudi-single.ipynb
@@ -392,7 +392,7 @@
     "from langchain.docstore.document import Document\n",
     "from langchain.text_splitter import CharacterTextSplitter\n",
     "from langchain_community.document_loaders import TextLoader\n",
-    "from langchain.vectorstores.pgvector import PGVector\n",
+    "from langchain_postgres import PGVector\n",
     "from langchain_huggingface import HuggingFaceEndpointEmbeddings"
    ]
   },
@@ -417,8 +417,8 @@
     "embeddings = HuggingFaceEndpointEmbeddings(model=\"http://localhost:9002\", huggingfacehub_api_token=\"EMPTY\")\n",
     "store = PGVector(\n",
     "    collection_name=\"documents\",\n",
-    "    connection_string=\"postgresql+psycopg2://postgres:postgres@localhost:9003/postgres\",\n",
-    "    embedding_function=embeddings,\n",
+    "    connection=\"postgresql+psycopg2://postgres:postgres@localhost:9003/postgres\",\n",
+    "    embeddings=embeddings,\n",
     "    pre_delete_collection=True\n",
     ")"
    ]

--- a/PyTorch/Single_card_tutorials/RAG/requirements.txt
+++ b/PyTorch/Single_card_tutorials/RAG/requirements.txt
@@ -8,6 +8,7 @@ langchain
 langchain-experimental
 langchain-community
 langchain_huggingface
+langchain-postgres
 text-generation
 pgvector
 gradio


### PR DESCRIPTION
To get rid of deprecated warnings, replaced the deprecated api for PGVector with newer one recommended here:
https://api.python.langchain.com/en/latest/vectorstores/langchain_community.vectorstores.pgvector.PGVector.html