### PR TITLE
fix peft and optimum-habana versions

### DIFF
--- a/PyTorch/Single_card_tutorials/llama2_fine_tuning_inference_single.ipynb
+++ b/PyTorch/Single_card_tutorials/llama2_fine_tuning_inference_single.ipynb
@@ -66,7 +66,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "!{sys.executable} -m pip install peft==0.10.0"
+    "!{sys.executable} -m pip install peft==0.11.1"
    ]
   },
   {
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!{sys.executable} -m pip install -q optimum-habana==1.11.1"
+    "!{sys.executable} -m pip install -q optimum-habana==1.12.0"
    ]
   },
   {


### PR DESCRIPTION
For 1.16.2, optimum-habana verson 1.12.0 must be used according to the support matrix: https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix_v1.16.2.html#support-matrix-1-16-2