### PR TITLE
Triton Inference Server 

### DIFF
--- a/PyTorch/triton_inference_server/LICENSE
+++ b/PyTorch/triton_inference_server/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2025 Habana Labs, Ltd. an Intel Company. SPDX-License-Identifier: Apache-2.0
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/PyTorch/triton_inference_server/README.md
+++ b/PyTorch/triton_inference_server/README.md
@@ -3,7 +3,7 @@
 This document provides instructions on deploying hugging face transformer models on Triton Inference Server (TIS) with Intel® Gaudi® AI accelerator. The overal process involves:
 
 - Create a model repository
-- Build the conitaner image
+- Build the container image
 - Launch a Triton Inference Server
 - Query the server
 
@@ -20,9 +20,18 @@ The document is based on the following:
 > [!NOTE]
 > The tutorial is intended to be a reference example only. It may not be tuned for optimal performance.
 
+## Clone the tutorial
+
+The first step is to clone the repository
+
+```bash
+git clone https://github.com/HabanaAI/Gaudi-tutorials.git
+cd Gaudi-tutorials/PyTorch/triton_inference_server/
+```
+
 ## Create a Model Repository
 
-The first step is to create a model repository according to the structure detailed in Setting up the model repository and Model repository.
+Next, create a model repository according to the structure detailed in [setting up the model repository](https://github.com/triton-inference-server/tutorials/tree/main/Conceptual_Guide/Part_1-model_deployment#setting-up-the-model-repository) and [model repository](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_repository.md).
 To use the example models here, create a directory called `model_repository` and copy the `qwen2` model  into it:
 
 ```bash
@@ -32,13 +41,18 @@ cp -r qwen2/ model_repository/
 
 The `qwen2` folder is organized in the way Triton expects and contains two important files needed to serve models in Triton:
 
-- **config.pbtxt**: This file contians information on the backend use, model input/output details, and custom  parameters to use for execution. More information on the full range of model configuration
+- `config.pbtxt`: This file contians information on the backend use, model input/output details, and custom  parameters to use for execution. More information on the full range of model configuration
 properties Triton supports can be found [here](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/user_guide/model_configuration.html).
-- **model.py**: This file includes how Triton should handle the model during the initialization, execution, finalization stages. The Gaudi® AI accelerator specific details are given here. More information regarding python backend usage
+- `model.py`: This file includes how Triton should handle the model during the initialization, execution, finalization stages. More information regarding python backend usage
 can be found [here](https://github.com/triton-inference-server/python_backend#usage).
 
+A summary of the modifications made to the original triton files to enable Gaudi® AI accelerator is:
+
+- `model.py`: The `habana_args` class contains arguments specific to Gaudi® AI accelerator for proper model initialization and output generatation.
+- `utils.py`: This file contains Gaudi® AI accelerator helper functions defining the model initialization similar to ones in optimum-habana examples, i.e [`AutoModelForCausalLM`](https://github.com/huggingface/optimum-habana/blob/df7db95e47be58e39eba3ba73cf7a68f6e81c46a/examples/language-modeling/run_clm.py#L492-L502), quantization, distibuted training, etc.
+
 > [!NOTE]
-> To enable a generic model on Gaudi, some modifications are required as detailed in [PyTorch Model Porting](https://docs.habana.ai/en/latest/PyTorch/PyTorch_Model_Porting/index.html#pytorch-user-guide) and [Getting Started with Inference on Intel Gaudi](https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Getting_Started_with_Inference.html#inference-using-native-fw).
+> To enable a generic model on Gaudi® AI accelerator, some modifications are required as detailed in [PyTorch Model Porting](https://docs.habana.ai/en/latest/PyTorch/PyTorch_Model_Porting/index.html#pytorch-user-guide) and [Getting Started with Inference on Intel Gaudi](https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Getting_Started_with_Inference.html#inference-using-native-fw).
 
 ## Build a Triton Container Image
 

--- a/PyTorch/triton_inference_server/README.md
+++ b/PyTorch/triton_inference_server/README.md
@@ -48,6 +48,7 @@ Since a Triton server is launched within a Docker container, a container image t
 git clone https://github.com/HabanaAI/Setup_and_Install/
 cd Setup_and_Install/dockerfiles/triton
 make build BUILD_OS=ubuntu22.04
+cd ../../..
 ```
 
 ## Launch the Triton Inference Server
@@ -61,7 +62,7 @@ docker run -it --runtime=habana --name triton_backend --rm -e HABANA_VISIBLE_DEV
 ```
 
 > [!NOTE]
-> In the command above, change the `ImageName` as needed for different driver version.
+> In the command above, change the `ImageName` for different driver versions, and the `$PWD/model_repository/` if needed.
 
 > [!WARNING]
 > For private models, one need to request access to the model and add the access token to the docker command `-e PRIVATE_REPO_TOKEN=<hf_your_huggingface_access_token>`.

--- a/PyTorch/triton_inference_server/README.md
+++ b/PyTorch/triton_inference_server/README.md
@@ -20,9 +20,6 @@ The document is based on the following:
 > [!NOTE]
 > The tutorial is intended to be a reference example only. It may not be tuned for optimal performance.
 
-> [!WARNING]
-> The number of available Intel® Gaudi® AI accelerator in your contianer should be (at least) equal to number of deployed models.
-
 ## Create a Model Repository
 
 The first step is to create a model repository according to the structure detailed in Setting up the model repository and Model repository.
@@ -62,9 +59,6 @@ ImageName=triton-installer-2.6.0-ubuntu22.04:1.21.0-555
 docker run -it --runtime=habana --name triton_backend --rm -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice \
 --net=host --ipc=host -v $PWD/model_repository/:/root/model_repository/ ${ImageName}
 ```
-
-> [!NOTE]
-> In the command above, the shared `model_repository` directory created ealier is used.  
 
 > [!NOTE]
 > In the command above, change the `ImageName` as needed for different driver version.
@@ -122,7 +116,8 @@ pip install tritonclient gevent geventhttpclient -q
 python client.py --model_name qwen2
 ```
 
-Part of the respond appears as follow: 
+Part of the respond appears as follow:
+
 ```bash
 ----- Processing: model qwen2 ----- 
 -----Stats: model qwen2 ----- 
@@ -133,5 +128,33 @@ Output: [b"I am working on a project where I need to create a function that take
 > [!NOTE]
 > To use Triton on the client side with Intel® Gaudi®, no specific changes are required. Please refer to [Building a client application](https://github.com/triton-inference-server/tutorials/tree/main/Conceptual_Guide/Part_1-model_deployment#building-a-client-application) section and other details in the [client](https://github.com/triton-inference-server/client) documentation to customize your script.
 
-
 ## Host Multiple Models
+
+Thus far, only one model has been loaded. Triton is capable of loading multiple models as once. To do this, once can add a second model to the model repository:
+
+```bash
+cp -r llama2/ model_repository/
+```
+
+Again, re-run model launch command above, and wait for the confirmation of successful server launch, i.e.:
+
+```bash
+.
+.
+I0605 22:07:17.252902 1929 server.cc:676]
++--------+---------+--------+
+| Model  | Version | Status |
++--------+---------+--------+
+| llama2 | 1       | READY  |
+| qwen2  | 1       | READY  |
++--------+---------+--------+
+```
+
+Next, repeat the steps to query the server with `clinet.py` and update the model list passed via `--model_name`, i.e.
+
+```py
+python client.py --model_name qwen2,llama2
+```
+
+> [!WARNING]
+> The number of available Intel® Gaudi® AI accelerator in your contianer should be (at least) equal to number of deployed models.

--- a/PyTorch/triton_inference_server/README.md
+++ b/PyTorch/triton_inference_server/README.md
@@ -4,7 +4,7 @@ This document provides instructions on deploying hugging face transformer models
 
 - Create a model repository
 - Build the conitaner image
-- Lunch a Triton Inference Server
+- Launch a Triton Inference Server
 - Query the server
 
 For the purpose of this tutorial, the following models will be deployed:
@@ -42,7 +42,7 @@ can be found [here](https://github.com/triton-inference-server/python_backend#us
 
 ## Build a Triton Container Image
 
-Since a Triton server is launched within a Docker container, a container image tailored for Intel® Gaudi® AI accelerator is needed. Based on the guidelines detailed in the [Setup_and_Install GitHub repository](https://github.com/HabanaAI/Setup_and_Install/tree/main/dockerfiles), once can build such image:
+Since a Triton server is launched within a Docker container, a container image tailored for Intel® Gaudi® AI accelerator is needed. Based on the guidelines detailed in the [Setup_and_Install GitHub repository](https://github.com/HabanaAI/Setup_and_Install/tree/main/dockerfiles), one can build such image:
 
 ```bash
 git clone https://github.com/HabanaAI/Setup_and_Install/
@@ -53,7 +53,7 @@ cd ../../..
 
 ## Launch the Triton Inference Server
 
-Once the image is built, once can launch the Triton Inference Server in a container with the following command:
+Once the image is built, one can launch the Triton Inference Server in a container with the following command:
 
 ```bash
 ImageName=triton-installer-2.6.0-ubuntu22.04:1.21.0-555
@@ -65,9 +65,9 @@ docker run -it --runtime=habana --name triton_backend --rm -e HABANA_VISIBLE_DEV
 > In the command above, change the `ImageName` for different driver versions, and the `$PWD/model_repository/` if needed.
 
 > [!WARNING]
-> For private models, one need to request access to the model and add the access token to the docker command `-e PRIVATE_REPO_TOKEN=<hf_your_huggingface_access_token>`.
+> To access private models, you must request permission and include the Hugging Face access token in the Docker command: `-e PRIVATE_REPO_TOKEN=<hf_your_huggingface_access_token>`.
 
-Inside the docker, install the necessary prerequisites and lunch the server.
+Inside the docker, Install the necessary prerequisites and launch the server.
 
 ```bash
 pip install optimum[habana]
@@ -75,7 +75,7 @@ pip uninstall triton -y
 PT_HPU_LAZY_MODE=1 TORCH_DEVICE_BACKEND_AUTOLOAD=0 tritonserver --model-repository /root/model_repository/
 ```
 
-Once the server is successfully  launched, the following outputs will be in the console:
+Once the server is successfully launched, the following outputs will be in the console:
 
 ```bash
 I0605 19:30:49.849066 98 grpc_server.cc:2495] Started GRPCInferenceService at 0.0.0.0:8001
@@ -96,7 +96,7 @@ docker exec -it triton_backend bash
 curl -v localhost:8000/v2/health/ready 
 ```
 
-A sucessful respond appears as:
+A successful response appears as follows:
 
 ```bash
 * Mark bundle as not supporting multiuse
@@ -107,7 +107,7 @@ A sucessful respond appears as:
 * Connection #0 to host localhost left intact
 ```
 
-Finally install the `clinet.py` prerequisites and query the server
+Finally install the `client.py` prerequisites and query the server
 
 ```bash
 pip install tritonclient gevent geventhttpclient -q 
@@ -117,7 +117,7 @@ pip install tritonclient gevent geventhttpclient -q
 python client.py --model_name qwen2
 ```
 
-Part of the respond appears as follow:
+If the execution is successful, part of the response would be:
 
 ```bash
 ----- Processing: model qwen2 ----- 
@@ -131,17 +131,15 @@ Output: [b"I am working on a project where I need to create a function that take
 
 ## Host Multiple Models
 
-Thus far, only one model has been loaded. Triton is capable of loading multiple models as once. To do this, once can add a second model to the model repository:
+Thus far, only one model has been loaded. Triton is capable of loading multiple models at once. To do so, add a second model to the model repository:
 
 ```bash
 cp -r llama2/ model_repository/
 ```
 
-Again, re-run model launch command above, and wait for the confirmation of successful server launch, i.e.:
+Re-run the server command and wait until the server has completed startup. If both models are started properly, the log should show the following output:
 
 ```bash
-.
-.
 I0605 22:07:17.252902 1929 server.cc:676]
 +--------+---------+--------+
 | Model  | Version | Status |
@@ -151,11 +149,11 @@ I0605 22:07:17.252902 1929 server.cc:676]
 +--------+---------+--------+
 ```
 
-Next, repeat the steps to query the server with `clinet.py` and update the model list passed via `--model_name`, i.e.
+Next, repeat the steps to query the server with `client.py` and update the model list passed via `--model_name`, i.e.
 
 ```py
 python client.py --model_name qwen2,llama2
 ```
 
 > [!WARNING]
-> The number of available Intel® Gaudi® AI accelerator in your contianer should be (at least) equal to number of deployed models.
+> The container will require access to at least one Intel® Gaudi® AI accelerator for each of the models deployed.

--- a/PyTorch/triton_inference_server/README.md
+++ b/PyTorch/triton_inference_server/README.md
@@ -1,0 +1,137 @@
+# Triton Inference Server with Gaudi
+
+This document provides instructions on deploying hugging face transformer models on Triton Inference Server (TIS) with Intel® Gaudi® AI accelerator. The overal process involves:
+
+- Create a model repository
+- Build the conitaner image
+- Lunch a Triton Inference Server
+- Query the server
+
+For the purpose of this tutorial, the following models will be deployed:
+
+- [huggyllama/llama-7b](https://huggingface.co/huggyllama/llama-7b)
+- [Qwen/Qwen2-1.5B-Instruct](https://huggingface.co/Qwen/Qwen2-1.5B-Instruct)
+
+The document is based on the following:
+
+- [Triton Inference Server Quick Start Guide](https://github.com/triton-inference-server/server/blob/main/docs/getting_started/quickstart.md).
+- [Deploying Hugging Face Transformer Models in Triton](https://github.com/triton-inference-server/tutorials/blob/17331012af74eab68ad7c86d8a4ae494272ca4f7/Quick_Deploy/HuggingFaceTransformers/README.md)
+
+> [!NOTE]
+> The tutorial is intended to be a reference example only. It may not be tuned for optimal performance.
+
+> [!WARNING]
+> The number of available Intel® Gaudi® AI accelerator in your contianer should be (at least) equal to number of deployed models.
+
+## Create a Model Repository
+
+The first step is to create a model repository according to the structure detailed in Setting up the model repository and Model repository.
+To use the example models here, create a directory called `model_repository` and copy the `qwen2` model  into it:
+
+```bash
+mkdir -p model_repository
+cp -r qwen2/ model_repository/
+```
+
+The `qwen2` folder is organized in the way Triton expects and contains two important files needed to serve models in Triton:
+
+- **config.pbtxt**: This file contians information on the backend use, model input/output details, and custom  parameters to use for execution. More information on the full range of model configuration
+properties Triton supports can be found [here](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/user_guide/model_configuration.html).
+- **model.py**: This file includes how Triton should handle the model during the initialization, execution, finalization stages. The Gaudi® AI accelerator specific details are given here. More information regarding python backend usage
+can be found [here](https://github.com/triton-inference-server/python_backend#usage).
+
+> [!NOTE]
+> To enable a generic model on Gaudi, some modifications are required as detailed in [PyTorch Model Porting](https://docs.habana.ai/en/latest/PyTorch/PyTorch_Model_Porting/index.html#pytorch-user-guide) and [Getting Started with Inference on Intel Gaudi](https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Getting_Started_with_Inference.html#inference-using-native-fw).
+
+## Build a Triton Container Image
+
+Since a Triton server is launched within a Docker container, a container image tailored for Intel® Gaudi® AI accelerator is needed. Based on the guidelines detailed in the [Setup_and_Install GitHub repository](https://github.com/HabanaAI/Setup_and_Install/tree/main/dockerfiles), once can build such image:
+
+```bash
+git clone https://github.com/HabanaAI/Setup_and_Install/
+cd Setup_and_Install/dockerfiles/triton
+make build BUILD_OS=ubuntu22.04
+```
+
+## Launch the Triton Inference Server
+
+Once the image is built, once can launch the Triton Inference Server in a container with the following command:
+
+```bash
+ImageName=triton-installer-2.6.0-ubuntu22.04:1.21.0-555
+docker run -it --runtime=habana --name triton_backend --rm -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice \
+--net=host --ipc=host -v $PWD/model_repository/:/root/model_repository/ ${ImageName}
+```
+
+> [!NOTE]
+> In the command above, the shared `model_repository` directory created ealier is used.  
+
+> [!NOTE]
+> In the command above, change the `ImageName` as needed for different driver version.
+
+> [!WARNING]
+> For private models, one need to request access to the model and add the access token to the docker command `-e PRIVATE_REPO_TOKEN=<hf_your_huggingface_access_token>`.
+
+Inside the docker, install the necessary prerequisites and lunch the server.
+
+```bash
+pip install optimum[habana]
+pip uninstall triton -y
+PT_HPU_LAZY_MODE=1 TORCH_DEVICE_BACKEND_AUTOLOAD=0 tritonserver --model-repository /root/model_repository/
+```
+
+Once the server is successfully  launched, the following outputs will be in the console:
+
+```bash
+I0605 19:30:49.849066 98 grpc_server.cc:2495] Started GRPCInferenceService at 0.0.0.0:8001
+I0605 19:30:49.849242 98 http_server.cc:4619] Started HTTPService at 0.0.0.0:8000
+I0605 19:30:49.890324 98 http_server.cc:282] Started Metrics Service at 0.0.0.0:8002
+```
+
+> [!WARNING]
+> Review the [Intel® Gaudi® PyTorch bridge documentation](https://docs.habana.ai/en/latest/PyTorch/Reference/PyTorch_Gaudi_Theory_of_Operations.html#execution-modes) to choose the proper exectuion mode for your model.
+
+## Query the Server
+
+Copy over the `client.py` to the Triton container and check the server status.
+
+```bash
+docker cp client.py triton_backend:/opt/tritonserver
+docker exec -it triton_backend bash
+curl -v localhost:8000/v2/health/ready 
+```
+
+A sucessful respond appears as:
+
+```bash
+* Mark bundle as not supporting multiuse
+< HTTP/1.1 200 OK
+< Content-Length: 0
+< Content-Type: text/plain
+< 
+* Connection #0 to host localhost left intact
+```
+
+Finally install the `clinet.py` prerequisites and query the server
+
+```bash
+pip install tritonclient gevent geventhttpclient -q 
+```
+
+```py
+python client.py --model_name qwen2
+```
+
+Part of the respond appears as follow: 
+```bash
+----- Processing: model qwen2 ----- 
+-----Stats: model qwen2 ----- 
+http client out: <tritonclient.http._requested_output.InferRequestedOutput object at 0x7feb2422b730>
+Output: [b"I am working on a project where I need to create a function that takes a list of integers as input and returns a new list containing only the even numbers from the original list. How can I achieve this using Python? You can solve this problem by defining a function that iterates through the given list of integers, checks if each number is even, and if so, adds it to a new list. Here's how you can do it:\n\n```python\ndef get_even_numbers(numbers):\n    even_numbers ="
+```
+
+> [!NOTE]
+> To use Triton on the client side with Intel® Gaudi®, no specific changes are required. Please refer to [Building a client application](https://github.com/triton-inference-server/tutorials/tree/main/Conceptual_Guide/Part_1-model_deployment#building-a-client-application) section and other details in the [client](https://github.com/triton-inference-server/client) documentation to customize your script.
+
+
+## Host Multiple Models

--- a/PyTorch/triton_inference_server/client.py
+++ b/PyTorch/triton_inference_server/client.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+import time
+from tritonclient.utils import *
+import tritonclient.http as httpclient
+import argparse
+
+
+def main(model_name):
+    client = httpclient.InferenceServerClient(url="localhost:8000")
+
+    prompt = ["I am", "you are"]
+    text_obj = np.array(prompt, dtype="object")  # .reshape((-1, 1))
+
+    input_text = httpclient.InferInput("INPUT0", text_obj.shape, np_to_triton_dtype(text_obj.dtype))
+    input_text.set_data_from_numpy(text_obj)
+
+    for _model in model_name:
+        print(f"----- Processing: model {_model} ----- ")
+        output_text = httpclient.InferRequestedOutput("OUTPUT0")
+        start = time.time()
+        try:
+            query_response = client.infer(model_name=_model, inputs=[input_text], outputs=[output_text])
+        except:
+            print(f"Model {_model} not found! skipping")
+            continue
+
+        end = time.time()
+
+        print(f"-----Stats: model {_model} ----- ")
+        print(f"http client out: {output_text}")
+        print(f"Output: {query_response.as_numpy('OUTPUT0')}")
+        print(f"Time taken: {end - start}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_name",
+        help="comma-separated model names",
+        default="llama2",
+        type=lambda t: [s.strip() for s in t.split(",")],
+    )
+    args = parser.parse_args()
+    main(args.model_name)

--- a/PyTorch/triton_inference_server/client.py
+++ b/PyTorch/triton_inference_server/client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025 Habana Labs, Ltd. an Intel Company. SPDX-License-Identifier: Apache-2.0
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/PyTorch/triton_inference_server/llama2/1/model.py
+++ b/PyTorch/triton_inference_server/llama2/1/model.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import logging
+
+# triton_python_backend_utils is available in every Triton Python model. You
+# need to use this module to create inference requests and responses. It also
+# contains some utility functions for extracting information from model_config
+# and converting Triton input/output types to numpy types.
+import triton_python_backend_utils as pb_utils
+import numpy as np
+
+
+import torch
+from utils import count_hpu_graphs, initialize_model
+from optimum.habana.utils import get_hpu_memory_stats
+import os
+
+
+class habana_args:
+    device = "hpu"
+    model_name_or_path = "huggyllama/llama-7b"  #'meta-llama/Llama-2-7b-chat-hf'
+    token = None
+    bf16 = False
+    use_hpu_graphs = True
+    use_lazy_mode = False
+    seed = 42
+    use_kv_cache = True
+    max_new_tokens = 100
+    max_inp_tokens = 1024
+    batch_size = -1
+    do_sample = True
+    num_beams = 1
+    num_return_sequences = 1
+    profiling_steps = 0
+    profiling_warmup_steps = 0
+    prompt = "I am"
+    local_rank = ""
+    world_size = ""
+    global_rank = ""
+    fp8 = False
+    model_revision = "main"
+    peft_model = None
+    skip_hash_with_views = True
+    bad_words = None
+    force_words = None
+    bucket_size = -1
+    trim_logits = True
+    attn_softmax_bf16 = True
+    limit_hpu_graphs = True
+    reuse_cache = True
+    kv_cache_fp8 = True
+    attn_batch_split = 1
+    torch_compile = False
+    quant_config = os.getenv("QUANT_CONFIG", "")
+    load_quantized_model_with_inc = False
+    assistant_model = None
+    trust_remote_code = False
+    disk_offload = False
+    show_graphs_count = False
+    local_quantized_inc_model_path = None
+    load_quantized_model_with_autogptq = False
+    load_quantized_model_with_autoawq = False
+    bucket_internal = False
+    top_k = None
+    penalty_alpha = None
+    clear_hpu_graphs_cache = False
+    reduce_recompile = False
+    use_flash_attention = False
+    flash_attention_recompute = False
+    flash_attention_causal_mask = False
+    flash_attention_fast_softmax = False
+    const_serialization_path = ""
+
+
+logging.basicConfig(
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    datefmt="%m/%d/%Y %H:%M:%S",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+
+class TritonPythonModel:
+    """Your Python model must use the same class name. Every Python model
+    that is created must have "TritonPythonModel" as the class name.
+    """
+
+    def initialize(self, args):
+        """`initialize` is called only once when the model is being loaded.
+        Implementing `initialize` function is optional. This function allows
+        the model to initialize any state associated with this model.
+
+        Parameters
+        ----------
+        args : dict
+          Both keys and values are strings. The dictionary keys and values are:
+          * model_config: A JSON string containing the model configuration
+          * model_instance_kind: A string containing model instance kind
+          * model_instance_device_id: A string containing model instance device ID
+          * model_repository: Model repository path
+          * model_version: Model version
+          * model_name: Model name
+        """
+        print("Initializing")
+        model, assistant_model, tokenizer, generation_config = initialize_model(
+            habana_args, logger
+        )
+
+        self.model = model
+        self.tokenizer = tokenizer
+        self.generation_config = generation_config
+
+        input_tokens = tokenizer.batch_encode_plus(
+            [habana_args.prompt], return_tensors="pt", padding=True
+        )
+        for t in input_tokens:
+            if torch.is_tensor(input_tokens[t]):
+                input_tokens[t] = input_tokens[t].to(habana_args.device)
+        outputs = self.model.generate(
+            **input_tokens,
+            generation_config=generation_config,
+            lazy_mode=True,
+            hpu_graphs=habana_args.use_hpu_graphs,
+            profiling_steps=habana_args.profiling_steps,
+            profiling_warmup_steps=habana_args.profiling_warmup_steps,
+        ).cpu()
+        print("prompt test:")
+        prompt_list = tokenizer.batch_decode(outputs, skip_special_tokens=True)
+        # print(prompt_list[0].encode("UTF-8"))
+        print(prompt_list[0])
+
+        print("Initialize finished")
+
+        # You must parse model_config. JSON string is not parsed here
+        self.model_config = model_config = json.loads(args["model_config"])
+
+        # Get OUTPUT0 configuration
+        output0_config = pb_utils.get_output_config_by_name(model_config, "OUTPUT0")
+
+        # Convert Triton types to numpy types
+        self.output0_dtype = pb_utils.triton_string_to_numpy(
+            output0_config["data_type"]
+        )
+
+    def execute(self, requests):
+        """`execute` MUST be implemented in every Python model. `execute`
+        function receives a list of pb_utils.InferenceRequest as the only
+        argument. This function is called when an inference request is made
+        for this model. Depending on the batching configuration (e.g. Dynamic
+        Batching) used, `requests` may contain multiple requests. Every
+        Python model, must create one pb_utils.InferenceResponse for every
+        pb_utils.InferenceRequest in `requests`. If there is an error, you can
+        set the error argument when creating a pb_utils.InferenceResponse
+
+        Parameters
+        ----------
+        requests : list
+          A list of pb_utils.InferenceRequest
+
+        Returns
+        -------
+        list
+          A list of pb_utils.InferenceResponse. The length of this list must
+          be the same as `requests`
+        """
+
+        output0_dtype = self.output0_dtype
+
+        responses = []
+
+        # Every Python backend must iterate over everyone of the requests
+        # and create a pb_utils.InferenceResponse for each of them.
+        for request in requests:
+            # Get INPUT0
+            inp = pb_utils.get_input_tensor_by_name(request, "INPUT0")
+            print("xxxxxxxxxxx:", inp)
+            input_text = [x.decode("utf8") for x in inp.as_numpy()]
+            print(input_text, type(input_text[0]))
+
+            input_tokens = self.tokenizer.batch_encode_plus(
+                input_text, return_tensors="pt", padding=True
+            )
+            for t in input_tokens:
+                if torch.is_tensor(input_tokens[t]):
+                    input_tokens[t] = input_tokens[t].to(habana_args.device)
+
+            outputs = self.model.generate(
+                **input_tokens,
+                generation_config=self.generation_config,
+                lazy_mode=True,
+                hpu_graphs=habana_args.use_hpu_graphs,
+                profiling_steps=habana_args.profiling_steps,
+                profiling_warmup_steps=habana_args.profiling_warmup_steps,
+            ).cpu()
+            out_0 = self.tokenizer.batch_decode(outputs, skip_special_tokens=True)
+            print([x.encode("utf8") for x in out_0])
+            # out_0 = ["asdfasdfasdf", "idiot"]
+
+            # Create output tensors. You need pb_utils.Tensor
+            # objects to create pb_utils.InferenceResponse.
+            out_tensor_0 = pb_utils.Tensor(
+                "OUTPUT0", np.array(out_0, dtype=self.output0_dtype)
+            )
+
+            # Create InferenceResponse. You can set an error here in case
+            # there was a problem with handling this inference request.
+            # Below is an example of how you can set errors in inference
+            # response:
+            #
+            # pb_utils.InferenceResponse(
+            #    output_tensors=..., TritonError("An error occurred"))
+            inference_response = pb_utils.InferenceResponse(
+                output_tensors=[out_tensor_0]
+            )
+            responses.append(inference_response)
+
+        # You should return a list of pb_utils.InferenceResponse. Length
+        # of this list must match the length of `requests` list.
+        return responses
+
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is OPTIONAL. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print("Cleaning up...")

--- a/PyTorch/triton_inference_server/llama2/1/model.py
+++ b/PyTorch/triton_inference_server/llama2/1/model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2025 Habana Labs, Ltd. an Intel Company. SPDX-License-Identifier: Apache-2.0
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/PyTorch/triton_inference_server/llama2/1/utils.py
+++ b/PyTorch/triton_inference_server/llama2/1/utils.py
@@ -1,0 +1,806 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+# Copyright (C) 2020-2021 Habana Labs, Ltd. an Intel Company
+###############################################################################
+
+import copy
+import glob
+import os
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers.utils import check_min_version
+
+from optimum.habana.checkpoint_utils import (
+    get_ds_injection_policy,
+    get_repo_root,
+    model_is_optimized,
+    model_on_meta,
+    write_checkpoints_json,
+)
+from optimum.habana.utils import (
+    check_habana_frameworks_version,
+    check_optimum_habana_min_version,
+    get_habana_frameworks_version,
+    set_seed,
+)
+
+
+def adjust_batch(batch, size):
+    curr_size = batch["input_ids"].shape[1]
+    if curr_size >= size:
+        adjusted_batch = {
+            "input_ids": batch["input_ids"][:, :size],
+            "attention_mask": batch["attention_mask"][:, :size],
+        }
+    else:
+        adjusted_batch = {}
+        for k in batch.keys():
+            last_colm = batch[k][:, -1]
+            expanded = last_colm.tile((size - curr_size, 1)).T
+            adjusted_batch[k] = torch.concat([batch[k], expanded], 1)
+    assert adjusted_batch["input_ids"].shape[1] == size
+    assert adjusted_batch["attention_mask"].shape[1] == size
+    return adjusted_batch
+
+
+def override_print(enable):
+    import builtins as __builtin__
+
+    builtin_print = __builtin__.print
+
+    def print(*args, **kwargs):
+        force = kwargs.pop("force", False)
+        if force or enable:
+            builtin_print(*args, **kwargs)
+
+    __builtin__.print = print
+
+
+def override_logger(logger, enable):
+    logger_info = logger.info
+
+    def info(*args, **kwargs):
+        force = kwargs.pop("force", False)
+        if force or enable:
+            logger_info(*args, **kwargs)
+
+    logger.info = info
+
+
+def count_hpu_graphs():
+    return len(glob.glob(".graph_dumps/*PreGraph*"))
+
+
+def override_prints(enable, logger):
+    override_print(enable)
+    override_logger(logger, enable)
+
+
+def setup_distributed(args):
+    args.local_rank = int(os.getenv("LOCAL_RANK", "0"))
+    args.world_size = int(os.getenv("WORLD_SIZE", "0"))
+    args.global_rank = int(os.getenv("RANK", "0"))
+
+
+def setup_inference(args, model):
+    import habana_frameworks.torch.core as htcore
+
+    habana_version = get_habana_frameworks_version()
+
+    print("Initializing inference mode")
+    # Keeping the if-else here for back compat. TODO remove later
+    if habana_version.major >= 1 and habana_version.minor >= 16:
+        htcore.hpu_initialize(model, mark_only_scales_as_const=True)
+    else:
+        const_marking = os.getenv("ENABLE_CONST_MARKING", "True")
+        if const_marking == "True":
+            htcore.hpu_initialize(model)
+    return model
+
+
+def setup_const_serialization(const_serialization_path):
+    import uuid
+
+    const_serialization_path = os.path.join(const_serialization_path + uuid.uuid4().hex)
+    os.makedirs(const_serialization_path)
+    from habana_frameworks.torch.hpu import enable_const_section_serialization
+
+    print("Serializing const params to {}".format(const_serialization_path))
+    enable_const_section_serialization(const_serialization_path, True)
+
+
+def setup_env(args):
+    # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
+    check_min_version("4.34.0")
+    check_optimum_habana_min_version("1.9.0.dev0")
+    # TODO: SW-167588 - WA for memory issue in hqt prep_model
+    os.environ.setdefault("EXPERIMENTAL_WEIGHT_SHARING", "FALSE")
+
+    if args.global_rank == 0 and not args.torch_compile and args.show_graphs_count:
+        os.environ.setdefault("GRAPH_VISUALIZATION", "true")
+        shutil.rmtree(".graph_dumps", ignore_errors=True)
+
+    if args.world_size > 0:
+        os.environ.setdefault("PT_HPU_LAZY_ACC_PAR_MODE", "0")
+        os.environ.setdefault("PT_HPU_ENABLE_LAZY_COLLECTIVES", "true")
+
+    if args.use_hpu_graphs and args.limit_hpu_graphs and not args.reuse_cache and args.bucket_internal:
+        # Based upon above conditions and below env variable,
+        # we can call HPU graphs clear_inputs().
+        os.environ.setdefault("PT_HPUGRAPH_DISABLE_TENSOR_CACHE", "1")
+
+    # Tweak generation so that it runs faster on Gaudi
+    from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
+
+    adapt_transformers_to_gaudi()
+
+
+def setup_device(args):
+    if args.device == "hpu":
+        import habana_frameworks.torch.core as htcore
+
+        if args.quant_config or args.load_quantized_model_with_inc or args.local_quantized_inc_model_path:
+            htcore.hpu_set_env()
+    return torch.device(args.device)
+
+
+# patching LinearAllreduce to use ScopedLinearAllReduce
+def patch_scoped_linear_all_reduce(model):
+    from deepspeed.module_inject.layers import LinearAllreduce
+
+    from optimum.habana.transformers.models.modeling_all_models import ScopedLinearAllReduce
+
+    for name, module in model.named_children():
+        if type(module) is LinearAllreduce:
+            SL = ScopedLinearAllReduce(mod=module)
+            setattr(model, name, SL)
+        patch_scoped_linear_all_reduce(module)
+
+
+def get_torch_compiled_model(model, logger):
+    # for gpt_bigcode, mpt, bloom, gpt2 model_type
+    if hasattr(model, "transformer"):
+        model.transformer = torch.compile(
+            model.transformer, backend="hpu_backend", options={"keep_input_mutations": True}
+        )
+    # for gpt_neox
+    elif hasattr(model, "gpt_neox"):
+        model.gpt_neox = torch.compile(model.gpt_neox, backend="hpu_backend", options={"keep_input_mutations": True})
+    # for llama, mistral, mixtral, qwen2
+    elif hasattr(model, "model"):
+        model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})
+    else:
+        logger.warning(
+            "In low performance case, please explicitly specify a module you want to wrap with `torch.compile`"
+        )
+        model = torch.compile(model, backend="hpu_backend", options={"keep_input_mutations": True})
+    return model
+
+
+def setup_quantization(model, args):
+    try:
+        from neural_compressor.torch.quantization import FP8Config, convert, prepare
+    except ImportError:
+        raise ImportError(
+            "Module neural_compressor is missing. Please use a newer Synapse version to use quantization."
+        )
+
+    config = FP8Config.from_json_file(args.quant_config)
+    if config.measure:
+        model = prepare(model, config)
+    if config.quantize:
+        model = convert(model, config)
+
+    return model
+
+
+def finalize_quantization(model):
+    try:
+        from neural_compressor.torch.quantization import finalize_calibration
+    except ImportError:
+        raise ImportError(
+            "Module neural_compressor is missing. Please use a newer Synapse version to use quantization."
+        )
+    finalize_calibration(model)
+
+
+def setup_model(args, model_dtype, model_kwargs, logger):
+    logger.info("Single-device run.")
+    print(f"debug=============", model_dtype, flush=True)
+    if args.assistant_model is None:
+        assistant_model = None
+    else:
+        logger.info(f"Using asssitant model {args.assistant_model}.")
+    if args.disk_offload:
+        from accelerate import infer_auto_device_map, init_empty_weights
+
+        config = AutoConfig.from_pretrained(args.model_name_or_path)
+        with init_empty_weights():
+            model = AutoModelForCausalLM.from_config(config)
+        max_memory = {"cpu": "10GiB"}
+        device_map = infer_auto_device_map(model, max_memory=max_memory, dtype=model_dtype)
+        model = AutoModelForCausalLM.from_pretrained(
+            args.model_name_or_path,
+            device_map=device_map,
+            offload_folder="/tmp/offload_folder/",
+            offload_state_dict=True,
+            torch_dtype=model_dtype,
+            **model_kwargs,
+        )
+    elif args.load_quantized_model_with_autogptq:
+        from transformers import GPTQConfig
+
+        quantization_config = GPTQConfig(bits=4, use_exllama=False)
+        model = AutoModelForCausalLM.from_pretrained(
+            args.model_name_or_path, torch_dtype=model_dtype, quantization_config=quantization_config, **model_kwargs
+        )
+    elif args.load_quantized_model_with_autoawq:
+        from transformers import AwqConfig
+
+        quantization_config = AwqConfig(bits=4, version="hpu")
+        model = AutoModelForCausalLM.from_pretrained(
+            args.model_name_or_path, torch_dtype=model_dtype, quantization_config=quantization_config, **model_kwargs
+        )
+    elif args.load_quantized_model_with_inc:
+        # TODO: This will be removed in v1.20 Synapse release
+        # Override neural_compressor split_rank_state_dict for loading neural_magic models on multi-cards.
+        import neural_compressor.torch.algorithms.fp8_quant.save_load as nc_sl
+
+        nc_sl.split_rank_state_dict = local_split_rank_state_dict
+
+        from neural_compressor.torch.quantization import load
+
+        model = load(model_name_or_path=args.model_name_or_path, format="huggingface", device="hpu", **model_kwargs)
+    elif args.local_quantized_inc_model_path:
+        org_model = AutoModelForCausalLM.from_pretrained(
+            args.model_name_or_path,
+            **model_kwargs,
+        )
+
+        from neural_compressor.torch.quantization import load
+
+        model = load(
+            model_name_or_path=args.local_quantized_inc_model_path,
+            format="default",
+            device="hpu",
+            original_model=org_model,
+            **model_kwargs,
+        )
+    else:
+        if args.assistant_model is not None:
+            assistant_model = AutoModelForCausalLM.from_pretrained(
+                args.assistant_model, torch_dtype=model_dtype, **model_kwargs
+            )
+        if args.peft_model is not None:
+            model = peft_model(args, model_dtype, logger, **model_kwargs)
+        else:
+            model = AutoModelForCausalLM.from_pretrained(
+                args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs
+            )
+    if args.quant_config:
+        model = setup_quantization(model, args)
+
+    model = model.eval().to(args.device)
+    if args.assistant_model is not None:
+        assistant_model = assistant_model.eval().to(args.device)
+
+    if args.use_hpu_graphs:
+        from habana_frameworks.torch.hpu import wrap_in_hpu_graph
+
+        from optimum.habana.transformers.trainer import _is_peft_model
+
+        if check_habana_frameworks_version("1.13.0") and model.config.model_type == "falcon":
+            model = wrap_in_hpu_graph(model, hash_with_views=False)
+        else:
+            max_graphs = getattr(args, "max_graphs", None)
+            model = wrap_in_hpu_graph(model, max_graphs=max_graphs)
+        if args.assistant_model is not None:
+            assistant_model = wrap_in_hpu_graph(assistant_model)
+        if _is_peft_model(model):
+            model.base_model = wrap_in_hpu_graph(model.base_model)
+            if model.peft_type == "ADAPTION_PROMPT":
+                model.base_model.model = wrap_in_hpu_graph(model.base_model.model)
+
+    if args.torch_compile:
+        model = get_torch_compiled_model(model, logger)
+        assert "PT_HPU_LAZY_MODE" in os.environ and os.environ["PT_HPU_LAZY_MODE"] == "0", (
+            "Please set PT_HPU_LAZY_MODE=0 on command line when using `--torch_compile`"
+        )
+        # if args.assistant_model is not None:
+        #     assistant_model = get_torch_compiled_model(assistant_model, logger)
+    return model, assistant_model
+
+
+def setup_distributed_model_tp(args, model_dtype, model_kwargs, logger, cache_dir):
+    from typing import Any, MutableMapping
+
+    from optimum.habana.distributed import serialization
+    from optimum.habana.distributed.strategy import TensorParallelStrategy
+
+    logger.info("Multi-device run.")
+
+    assert args.quant_config == "", "Fp8 is not enabled, unset QUANT_CONFIG"
+    assert args.assistant_model is None, "Assistant model must be None"
+
+    from torch import distributed as dist
+
+    if args.device == "hpu":
+        dist.init_process_group(backend="hccl")
+    else:
+        assert False, "Supports TP only on HPU"
+
+    torch._C._distributed_c10d._register_process_group("default", dist.group.WORLD)
+    logger.info("Creating Model")
+    config = AutoConfig.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs)
+    model_kwargs = {}
+    model_kwargs["parallel_strategy"] = TensorParallelStrategy()
+    model = AutoModelForCausalLM.from_config(config, torch_dtype=model_dtype, **model_kwargs)
+
+    initial_device = torch.device("cpu")
+    source = "hf"
+    checkpoint_sharding = None
+    lazy_sd: MutableMapping[str, Any] = {}
+    logger.info("Loading Checkpoints")
+    lazy_sd = serialization.load_state_dict(
+        cache_dir,
+        source=source,
+        distributed_strategy=args.parallel_strategy,
+        checkpoint_sharding=None,
+        initial_device=initial_device,
+        rank=args.global_rank,
+        world_size=args.world_size,
+    )
+    architecture = "llama"
+    if len(lazy_sd):
+        serialization.load_state_dict_into_model(
+            model,
+            lazy_sd,
+            architecture,
+            source,
+            args.parallel_strategy,
+            checkpoint_sharding,
+            initial_device,
+            args.local_rank,
+            args.world_size,
+        )
+
+    model = model.eval().to(args.device)
+
+    if args.use_hpu_graphs:
+        from habana_frameworks.torch.hpu import wrap_in_hpu_graph
+
+        model = wrap_in_hpu_graph(model)
+
+    if args.torch_compile:
+        model = get_torch_compiled_model(model, logger)
+
+    return model, args.assistant_model
+
+
+def setup_distributed_model_ep(args, model_dtype, model_kwargs, logger):
+    logger.info("Multi-device ep run.")
+
+    assert args.quant_config == "", "Fp8 is not enabled, unset QUANT_CONFIG"
+    assert args.assistant_model is None, "Assistant model must be None"
+
+    from torch import distributed as dist
+
+    if args.device == "hpu":
+        dist.init_process_group(backend="hccl")
+    else:
+        assert False, "Supports EP only on HPU"
+
+    torch._C._distributed_c10d._register_process_group("default", dist.group.WORLD)
+    logger.info("Creating Model")
+    config = AutoConfig.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs)
+    config.update({"ep_size": args.world_size})
+
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_name_or_path,
+        config=config,
+        torch_dtype=model_dtype,
+        **model_kwargs,
+    )
+
+    model = model.eval().to(args.device)
+
+    if args.use_hpu_graphs:
+        from habana_frameworks.torch.hpu import wrap_in_hpu_graph
+
+        model = wrap_in_hpu_graph(model)
+
+    if args.torch_compile:
+        model = get_torch_compiled_model(model)
+
+    return model, args.assistant_model
+
+
+def setup_distributed_model(args, model_dtype, model_kwargs, logger):
+    import deepspeed
+
+    logger.info("DeepSpeed is enabled.")
+    deepspeed.init_distributed(dist_backend="hccl")
+    config = AutoConfig.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs)
+
+    keep_module_on_host = False
+    if "Llama-3.1-405B" in args.model_name_or_path:
+        keep_module_on_host = True
+
+    load_to_meta = False if keep_module_on_host else model_on_meta(config)
+
+    if args.assistant_model is None:
+        assistant_model = None
+    else:
+        logger.info(f"Using asssitant model {args.assistant_model}.")
+
+    if load_to_meta:
+        # Construct model with fake meta tensors, later will be replaced on devices during ds-inference ckpt load
+        with deepspeed.OnDevice(dtype=model_dtype, device="meta"):
+            if (
+                hasattr(config, "rope_scaling")
+                and config.rope_scaling
+                and config.rope_scaling["rope_type"] == "llama3"
+                and config.max_position_embeddings > 8192
+            ):
+                config.max_position_embeddings = 8192
+            model = AutoModelForCausalLM.from_config(config, torch_dtype=model_dtype)
+
+        # Model loaded to meta is managed differently
+        checkpoints_json = tempfile.NamedTemporaryFile(suffix=".json", mode="+w")
+
+        # For PEFT models, write the merged model on disk to be able to load it on the meta device
+        if args.peft_model is not None:
+            merged_model_dir = "/tmp/text_generation_merged_peft_model"
+            if args.local_rank == 0:
+                if Path(merged_model_dir).is_dir():
+                    shutil.rmtree(merged_model_dir)
+                peft_model(args, model_dtype, logger, **model_kwargs).save_pretrained(merged_model_dir)
+            torch.distributed.barrier()
+
+        write_checkpoints_json(
+            merged_model_dir if args.peft_model is not None else args.model_name_or_path,
+            args.local_rank,
+            checkpoints_json,
+            token=args.token,
+        )
+    else:
+        # TODO: revisit placement on CPU when auto-injection is possible
+        with deepspeed.OnDevice(dtype=model_dtype, device="cpu"):
+            if args.peft_model is not None:
+                model = peft_model(args, model_dtype, logger, **model_kwargs)
+            else:
+                model = AutoModelForCausalLM.from_pretrained(
+                    args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs
+                )
+    model.eval()
+
+    if args.assistant_model is not None:
+        assistant_model = AutoModelForCausalLM.from_pretrained(
+            args.assistant_model, torch_dtype=model_dtype, **model_kwargs
+        ).eval()
+
+    # Initialize the model
+    ds_inference_kwargs = {"dtype": model_dtype}
+    ds_inference_kwargs["keep_module_on_host"] = keep_module_on_host
+    ds_inference_kwargs["tensor_parallel"] = {"tp_size": args.world_size}
+    ds_inference_kwargs["enable_cuda_graph"] = args.use_hpu_graphs
+    ds_inference_kwargs["injection_policy"] = get_ds_injection_policy(config)
+    if load_to_meta:
+        ds_inference_kwargs["checkpoint"] = checkpoints_json.name
+
+    model = deepspeed.init_inference(model, **ds_inference_kwargs)
+    model = model.module
+    if model.config.model_type in ["llama", "falcon", "qwen2", "starcoder2", "gemma"]:
+        patch_scoped_linear_all_reduce(model)
+
+    if args.quant_config:
+        model = setup_quantization(model, args)
+
+    if args.torch_compile:
+        model = get_torch_compiled_model(model, logger)
+        # if args.assistant_model is not None:
+        #     assistant_model = get_torch_compiled_model(assistant_model, logger)
+    return model, assistant_model
+
+
+def peft_model(args, model_dtype, logger, **model_kwargs):
+    import importlib.util
+
+    if importlib.util.find_spec("peft") is None:
+        raise ImportError("The `peft` package is not installed, please run: `pip install peft`.")
+    from peft import AutoPeftModelForCausalLM
+    from peft.config import PeftConfigMixin
+
+    base_model_name = PeftConfigMixin.from_pretrained(
+        args.peft_model,
+        token=model_kwargs["token"] if "token" in model_kwargs else None,
+    ).base_model_name_or_path
+
+    base_model_is_local = Path(base_model_name).is_dir()
+    if not base_model_is_local:
+        # Check if the base model path to a remote repository on the HF Hub exists
+        from huggingface_hub import list_repo_files
+
+        try:
+            list_repo_files(base_model_name)
+            base_model_is_remote = True
+        except Exception:
+            base_model_is_remote = False
+
+    if base_model_is_local or base_model_is_remote:
+        model = AutoPeftModelForCausalLM.from_pretrained(args.peft_model, torch_dtype=model_dtype, **model_kwargs)
+    else:
+        # Since the base model doesn't exist locally nor remotely, use `args.model_name_or_path` as the base model
+        logger.warning(
+            f"The base model `{base_model_name}` of the LoRA configuration associated"
+            f" to `{args.peft_model}` does not exist locally or remotely. Using "
+            f"`--model_name_or_path {args.model_name_or_path}` as a fall back for the base model."
+        )
+        from peft import PeftModel
+
+        model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs)
+        model = PeftModel.from_pretrained(model, args.peft_model, torch_dtype=model_dtype, **model_kwargs)
+    if hasattr(model, "merge_and_unload"):
+        model = model.merge_and_unload()
+        if model_dtype == torch.bfloat16:
+            model = model.to(torch.bfloat16)
+        return model
+    else:
+        from optimum.habana.peft.peft_model import gaudi_generate, gaudi_prepare_inputs_for_generation
+
+        model.__class__.generate = gaudi_generate
+        model.__class__.prepare_inputs_for_generation = gaudi_prepare_inputs_for_generation
+        if model.peft_type == "ADAPTION_PROMPT":
+            from peft import tuners
+
+            from optimum.habana.peft.layer import (
+                GaudiAdaptedAttention_getattr,
+                GaudiAdaptedAttentionPreAttnForward,
+            )
+
+            tuners.adaption_prompt.layer.AdaptedAttention.pre_attn_forward = GaudiAdaptedAttentionPreAttnForward
+            tuners.adaption_prompt.layer.AdaptedAttention.__getattr__ = GaudiAdaptedAttention_getattr
+
+        return model
+
+
+def setup_tokenizer(args, model, assistant_model, logger):
+    tokenizer_kwargs = {
+        "revision": args.model_revision,
+        "token": args.token,
+        "trust_remote_code": args.trust_remote_code,
+    }
+    if args.bad_words is not None or args.force_words is not None:
+        tokenizer_kwargs["add_prefix_space"] = True
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, **tokenizer_kwargs)
+    if not model.config.is_encoder_decoder:
+        tokenizer.padding_side = "left"
+
+    if model.config.model_type == "llama":
+        if model.generation_config.pad_token_id is None:
+            if isinstance(model.generation_config.eos_token_id, int):
+                model.generation_config.pad_token_id = model.generation_config.eos_token_id
+            elif isinstance(model.generation_config.eos_token_id, list):
+                model.generation_config.pad_token_id = model.generation_config.eos_token_id[0]
+        if assistant_model is not None:
+            if assistant_model.generation_config.pad_token_id is None:
+                if isinstance(assistant_model.generation_config.eos_token_id, int):
+                    assistant_model.generation_config.pad_token_id = assistant_model.generation_config.eos_token_id
+                elif isinstance(assistant_model.generation_config.eos_token_id, list):
+                    assistant_model.generation_config.pad_token_id = assistant_model.generation_config.eos_token_id[0]
+        tokenizer.bos_token_id = model.generation_config.bos_token_id
+        if isinstance(model.generation_config.eos_token_id, int):
+            tokenizer.eos_token_id = model.generation_config.eos_token_id
+        elif isinstance(model.generation_config.eos_token_id, list):
+            tokenizer.eos_token_id = model.generation_config.eos_token_id[0]
+        tokenizer.pad_token_id = model.generation_config.pad_token_id
+        tokenizer.pad_token = tokenizer.decode(tokenizer.pad_token_id)
+        tokenizer.eos_token = tokenizer.decode(tokenizer.eos_token_id)
+        tokenizer.bos_token = tokenizer.decode(tokenizer.bos_token_id)
+    if model.config.model_type == "persimmon":
+        model.generation_config.pad_token_id = model.generation_config.eos_token_id
+        if assistant_model is not None:
+            assistant_model.generation_config.pad_token_id = assistant_model.generation_config.eos_token_id
+        tokenizer.bos_token_id = model.generation_config.bos_token_id
+        tokenizer.eos_token_id = model.generation_config.eos_token_id
+        tokenizer.pad_token_id = model.generation_config.pad_token_id
+        tokenizer.pad_token = tokenizer.decode(tokenizer.pad_token_id)
+        tokenizer.eos_token = tokenizer.decode(tokenizer.eos_token_id)
+        tokenizer.bos_token = tokenizer.decode(tokenizer.bos_token_id)
+
+    # HACK: MiniCPM3 does not support list EOS token ID generation config.
+    if model.config.model_type == "minicpm3" and isinstance(model.generation_config.eos_token_id, list):
+        logger.warning(
+            f"Model type {model.config.model_type} does not support list style EOS token ID in generation config. Only last eos token id will be used."
+        )
+        model.generation_config.eos_token_id = model.generation_config.eos_token_id[-1]
+
+    if model.config.model_type == "mpt":
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        if model.generation_config.pad_token_id is None:
+            model.generation_config.pad_token_id = tokenizer.eos_token_id
+
+    # Some models like GPT2 do not have a PAD token so we have to set it if necessary
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+        model.generation_config.pad_token_id = model.generation_config.eos_token_id
+        if assistant_model is not None:
+            assistant_model.generation_config.pad_token_id = assistant_model.generation_config.eos_token_id
+
+    return tokenizer, model, assistant_model
+
+
+def setup_generation_config(args, model, assistant_model, tokenizer):
+    bad_words_ids = None
+    force_words_ids = None
+    if args.bad_words is not None:
+        bad_words_ids = [tokenizer.encode(bad_word, add_special_tokens=False) for bad_word in args.bad_words]
+    if args.force_words is not None:
+        force_words_ids = [tokenizer.encode(force_word, add_special_tokens=False) for force_word in args.force_words]
+
+    is_optimized = model_is_optimized(model.config)
+
+    # Generation configuration
+    generation_config = copy.deepcopy(model.generation_config)
+    generation_config.max_new_tokens = args.max_new_tokens
+    generation_config.use_cache = args.use_kv_cache
+    generation_config.static_shapes = is_optimized and assistant_model is None
+    generation_config.bucket_size = args.bucket_size if is_optimized else -1
+    generation_config.bucket_internal = args.bucket_internal
+    generation_config.do_sample = args.do_sample
+    generation_config.num_beams = args.num_beams
+    generation_config.top_k = args.top_k
+    generation_config.penalty_alpha = args.penalty_alpha
+    generation_config.bad_words_ids = bad_words_ids
+    generation_config.force_words_ids = force_words_ids
+    generation_config.num_return_sequences = args.num_return_sequences
+    generation_config.trim_logits = args.trim_logits
+    generation_config.attn_softmax_bf16 = args.attn_softmax_bf16
+    generation_config.limit_hpu_graphs = args.limit_hpu_graphs
+    generation_config.clear_hpu_graphs_cache = args.clear_hpu_graphs_cache
+    generation_config.reuse_cache = args.reuse_cache
+    generation_config.reduce_recompile = args.reduce_recompile
+    if generation_config.reduce_recompile:
+        assert generation_config.bucket_size > 0
+    generation_config.use_flash_attention = args.use_flash_attention
+    generation_config.flash_attention_recompute = args.flash_attention_recompute
+    generation_config.flash_attention_causal_mask = args.flash_attention_causal_mask
+    generation_config.flash_attention_fast_softmax = args.flash_attention_fast_softmax
+    generation_config.trust_remote_code = args.trust_remote_code
+    generation_config.valid_sequence_lengths = None
+    generation_config.attn_batch_split = args.attn_batch_split
+
+    return generation_config
+
+
+def exclude_hpu_graph_configs(args):
+    # Excluded configs for batch size 1 for hpu graph
+    if args.batch_size == 1 and args.limit_hpu_graphs:
+        if "falcon-180B" in args.model_name_or_path or "falcon-180b" in args.model_name_or_path:
+            return False
+        if args.world_size == 2 or args.world_size == 4 or args.world_size == 8:
+            if args.quant_config or args.load_quantized_model_with_inc or args.local_quantized_inc_model_path:
+                if args.max_input_tokens >= 8192 and args.max_new_tokens >= 128:
+                    return False
+            else:
+                if args.max_input_tokens >= 4096 and args.max_new_tokens >= 128:
+                    return False
+        return True
+    else:
+        return False
+
+
+def initialize_model(args, logger):
+    init_start = time.perf_counter()
+    setup_distributed(args)
+    if not args.world_size > 0 and args.attn_batch_split > 1:
+        logger.warning("Disabling attention batch splitting as it's unnecessary for single-card execution")
+        args.attn_batch_split = 1
+    if exclude_hpu_graph_configs(args):
+        args.limit_hpu_graphs = False
+    override_prints(args.global_rank == 0 or args.verbose_workers, logger)
+    setup_env(args)
+    setup_device(args)
+    set_seed(args.seed)
+    cache_dir = get_repo_root(args.model_name_or_path, local_rank=args.local_rank, token=args.token)
+    if args.assistant_model is not None:
+        get_repo_root(args.assistant_model, local_rank=args.local_rank, token=args.token)
+    use_deepspeed = args.world_size > 0
+    if use_deepspeed or args.bf16:
+        model_dtype = torch.bfloat16
+    else:
+        model_dtype = torch.float
+        args.attn_softmax_bf16 = False
+    print(f"debug=============", model_dtype, flush=True)
+    model_kwargs = {
+        "revision": args.model_revision,
+        "token": args.token,
+        "trust_remote_code": args.trust_remote_code,
+    }
+    if args.load_quantized_model_with_inc or args.local_quantized_inc_model_path:
+        model_kwargs["torch_dtype"] = torch.bfloat16
+
+    if args.trust_remote_code:
+        logger.warning("`trust_remote_code` is set, there is no guarantee this model works properly and it may fail")
+
+    model, assistant_model = (
+        setup_model(args, model_dtype, model_kwargs, logger)
+        if not use_deepspeed or args.load_quantized_model_with_inc
+        else setup_distributed_model(args, model_dtype, model_kwargs, logger)
+        if args.parallel_strategy == "none"
+        else setup_distributed_model_tp(args, model_dtype, model_kwargs, logger, cache_dir)
+        if args.parallel_strategy == "tp"
+        else setup_distributed_model_ep(args, model_dtype, model_kwargs, logger)
+    )
+
+    tokenizer, model, assistant_model = setup_tokenizer(args, model, assistant_model, logger)
+    generation_config = setup_generation_config(args, model, assistant_model, tokenizer)
+
+    if args.const_serialization_path:
+        setup_const_serialization(args.const_serialization_path)
+    if args.quant_config or args.load_quantized_model_with_inc or args.local_quantized_inc_model_path:
+        model = setup_inference(args, model)
+    init_end = time.perf_counter()
+    logger.info(f"Args: {args}")
+    logger.info(f"device: {args.device}, n_hpu: {args.world_size}, bf16: {model_dtype == torch.bfloat16}")
+    logger.info(f"Model initialization took {(init_end - init_start):.3f}s")
+    return model, assistant_model, tokenizer, generation_config
+
+
+def save_model(model, tokenizer, save_path):
+    """Saves the model and tokenizer in the huggingface format with neural_compressor."""
+    from neural_compressor.torch.quantization import save
+
+    save(model, save_path, format="huggingface")
+    tokenizer.save_pretrained(save_path)
+
+
+# TODO: This will be removed in v1.20 Synapse release
+# Override neural_compressor split_rank_state_dict for loading neural_magic models on multi-cards.
+def local_split_rank_state_dict(model, gathered_state_dict):
+    """split state_dict for current local_rank."""
+    from neural_compressor.torch.algorithms.fp8_quant.save_load import (
+        cur_accelerator,
+        local_rank,
+        split_weights,
+        world_size,
+    )
+
+    rank_state_dict = {}
+    for name, param in model.named_parameters():
+        if name in gathered_state_dict:
+            full_weight = gathered_state_dict[name]
+            if len(param.shape) != 0 and full_weight.shape != param.shape:
+                if full_weight.shape[0] != param.shape[0]:
+                    split_weight = split_weights(full_weight, world_size, local_rank, split_axis=0).clone()
+                elif full_weight.shape[1] != param.shape[1]:
+                    split_weight = split_weights(full_weight, world_size, local_rank, split_axis=1).clone()
+                else:
+                    split_weight = split_weights(full_weight, world_size, local_rank, split_axis=0).clone()
+            else:
+                split_weight = full_weight
+            rank_state_dict[name] = split_weight
+        cur_accelerator.synchronize()
+
+    return rank_state_dict
+

--- a/PyTorch/triton_inference_server/llama2/config.pbtxt
+++ b/PyTorch/triton_inference_server/llama2/config.pbtxt
@@ -1,0 +1,20 @@
+name: "llama2"
+backend: "python"
+
+input [
+  {
+    name: "INPUT0"
+    data_type: TYPE_STRING
+    dims: [ -1 ]
+  }
+]
+
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_STRING
+    dims: [ -1 ]
+  }
+]
+instance_group [{ kind: KIND_CPU }]
+

--- a/PyTorch/triton_inference_server/qwen2/1/model.py
+++ b/PyTorch/triton_inference_server/qwen2/1/model.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import logging
+
+# triton_python_backend_utils is available in every Triton Python model. You
+# need to use this module to create inference requests and responses. It also
+# contains some utility functions for extracting information from model_config
+# and converting Triton input/output types to numpy types.
+import triton_python_backend_utils as pb_utils
+import numpy as np
+
+
+import torch
+from utils import initialize_model
+import os
+
+
+class habana_args:
+    device = "hpu"
+    model_name_or_path = "Qwen/Qwen2-1.5B-Instruct"
+    token = None
+    bf16 = False
+    use_hpu_graphs = True
+    use_lazy_mode = False
+    seed = 42
+    use_kv_cache = True
+    max_new_tokens = 100
+    max_inp_tokens = 1024
+    batch_size = -1
+    do_sample = True
+    num_beams = 3
+    num_return_sequences = 1
+    profiling_steps = 0
+    profiling_warmup_steps = 0
+    prompt = "I am"
+    local_rank = ""
+    world_size = ""
+    global_rank = ""
+    fp8 = False
+    model_revision = "main"
+    peft_model = None
+    skip_hash_with_views = True
+    bad_words = None
+    force_words = None
+    bucket_size = -1
+    trim_logits = True
+    attn_softmax_bf16 = True
+    limit_hpu_graphs = True
+    reuse_cache = True
+    kv_cache_fp8 = True
+    attn_batch_split = 1
+    torch_compile = False
+    quant_config = os.getenv("QUANT_CONFIG", "")
+    load_quantized_model_with_inc = False
+    assistant_model = None
+    trust_remote_code = False
+    disk_offload = False
+    show_graphs_count = False
+    local_quantized_inc_model_path = None
+    load_quantized_model_with_autogptq = False
+    load_quantized_model_with_autoawq = False
+    bucket_internal = False
+    top_k = None
+    penalty_alpha = None
+    clear_hpu_graphs_cache = False
+    reduce_recompile = False
+    use_flash_attention = True
+    flash_attention_recompute = False
+    flash_attention_causal_mask = False
+    flash_attention_fast_softmax = False
+    const_serialization_path = ""
+
+
+logging.basicConfig(
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    datefmt="%m/%d/%Y %H:%M:%S",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+
+class TritonPythonModel:
+    """Your Python model must use the same class name. Every Python model
+    that is created must have "TritonPythonModel" as the class name.
+    """
+
+    def initialize(self, args):
+        """`initialize` is called only once when the model is being loaded.
+        Implementing `initialize` function is optional. This function allows
+        the model to initialize any state associated with this model.
+
+        Parameters
+        ----------
+        args : dict
+          Both keys and values are strings. The dictionary keys and values are:
+          * model_config: A JSON string containing the model configuration
+          * model_instance_kind: A string containing model instance kind
+          * model_instance_device_id: A string containing model instance device ID
+          * model_repository: Model repository path
+          * model_version: Model version
+          * model_name: Model name
+        """
+        print("Initializing")
+        model, assistant_model, tokenizer, generation_config = initialize_model(
+            habana_args, logger
+        )
+
+        self.model = model
+        self.tokenizer = tokenizer
+        self.generation_config = generation_config
+
+        input_tokens = tokenizer.batch_encode_plus(
+            [habana_args.prompt], return_tensors="pt", padding=True
+        )
+        for t in input_tokens:
+            if torch.is_tensor(input_tokens[t]):
+                input_tokens[t] = input_tokens[t].to(habana_args.device)
+        outputs = self.model.generate(
+            **input_tokens,
+            generation_config=generation_config,
+            lazy_mode=True,
+            hpu_graphs=habana_args.use_hpu_graphs,
+            profiling_steps=habana_args.profiling_steps,
+            profiling_warmup_steps=habana_args.profiling_warmup_steps,
+        ).cpu()
+        print("prompt test:")
+        prompt_list = tokenizer.batch_decode(outputs, skip_special_tokens=True)
+        print(prompt_list[0])
+
+        print("Initialize finished")
+
+        # You must parse model_config. JSON string is not parsed here
+        self.model_config = model_config = json.loads(args["model_config"])
+
+        # Get OUTPUT0 configuration
+        output0_config = pb_utils.get_output_config_by_name(model_config, "OUTPUT0")
+
+        # Convert Triton types to numpy types
+        self.output0_dtype = pb_utils.triton_string_to_numpy(
+            output0_config["data_type"]
+        )
+
+    def execute(self, requests):
+        """`execute` MUST be implemented in every Python model. `execute`
+        function receives a list of pb_utils.InferenceRequest as the only
+        argument. This function is called when an inference request is made
+        for this model. Depending on the batching configuration (e.g. Dynamic
+        Batching) used, `requests` may contain multiple requests. Every
+        Python model, must create one pb_utils.InferenceResponse for every
+        pb_utils.InferenceRequest in `requests`. If there is an error, you can
+        set the error argument when creating a pb_utils.InferenceResponse
+
+        Parameters
+        ----------
+        requests : list
+          A list of pb_utils.InferenceRequest
+
+        Returns
+        -------
+        list
+          A list of pb_utils.InferenceResponse. The length of this list must
+          be the same as `requests`
+        """
+
+        output0_dtype = self.output0_dtype
+
+        responses = []
+
+        # Every Python backend must iterate over everyone of the requests
+        # and create a pb_utils.InferenceResponse for each of them.
+        for request in requests:
+            # Get INPUT0
+            inp = pb_utils.get_input_tensor_by_name(request, "INPUT0")
+            print("xxxxxxxxxxx:", inp)
+            input_text = [x.decode("utf8") for x in inp.as_numpy()]
+            print(input_text, type(input_text[0]))
+
+            input_tokens = self.tokenizer.batch_encode_plus(
+                input_text, return_tensors="pt", padding=True
+            )
+            for t in input_tokens:
+                if torch.is_tensor(input_tokens[t]):
+                    input_tokens[t] = input_tokens[t].to(habana_args.device)
+
+            outputs = self.model.generate(
+                **input_tokens,
+                generation_config=self.generation_config,
+                lazy_mode=True,
+                hpu_graphs=habana_args.use_hpu_graphs,
+                profiling_steps=habana_args.profiling_steps,
+                profiling_warmup_steps=habana_args.profiling_warmup_steps,
+            ).cpu()
+            out_0 = self.tokenizer.batch_decode(outputs, skip_special_tokens=True)
+            print([x.encode("utf8") for x in out_0])
+            # out_0 = ["asdfasdfasdf", "idiot"]
+
+            # Create output tensors. You need pb_utils.Tensor
+            # objects to create pb_utils.InferenceResponse.
+            out_tensor_0 = pb_utils.Tensor(
+                "OUTPUT0", np.array(out_0, dtype=self.output0_dtype)
+            )
+
+            # Create InferenceResponse. You can set an error here in case
+            # there was a problem with handling this inference request.
+            # Below is an example of how you can set errors in inference
+            # response:
+            #
+            # pb_utils.InferenceResponse(
+            #    output_tensors=..., TritonError("An error occurred"))
+            inference_response = pb_utils.InferenceResponse(
+                output_tensors=[out_tensor_0]
+            )
+            responses.append(inference_response)
+
+        # You should return a list of pb_utils.InferenceResponse. Length
+        # of this list must match the length of `requests` list.
+        return responses
+
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is OPTIONAL. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print("Cleaning up...")

--- a/PyTorch/triton_inference_server/qwen2/1/model.py
+++ b/PyTorch/triton_inference_server/qwen2/1/model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2025 Habana Labs, Ltd. an Intel Company. SPDX-License-Identifier: Apache-2.0
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/PyTorch/triton_inference_server/qwen2/1/utils.py
+++ b/PyTorch/triton_inference_server/qwen2/1/utils.py
@@ -1,0 +1,806 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+# Copyright (C) 2020-2021 Habana Labs, Ltd. an Intel Company
+###############################################################################
+
+import copy
+import glob
+import os
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers.utils import check_min_version
+
+from optimum.habana.checkpoint_utils import (
+    get_ds_injection_policy,
+    get_repo_root,
+    model_is_optimized,
+    model_on_meta,
+    write_checkpoints_json,
+)
+from optimum.habana.utils import (
+    check_habana_frameworks_version,
+    check_optimum_habana_min_version,
+    get_habana_frameworks_version,
+    set_seed,
+)
+
+
+def adjust_batch(batch, size):
+    curr_size = batch["input_ids"].shape[1]
+    if curr_size >= size:
+        adjusted_batch = {
+            "input_ids": batch["input_ids"][:, :size],
+            "attention_mask": batch["attention_mask"][:, :size],
+        }
+    else:
+        adjusted_batch = {}
+        for k in batch.keys():
+            last_colm = batch[k][:, -1]
+            expanded = last_colm.tile((size - curr_size, 1)).T
+            adjusted_batch[k] = torch.concat([batch[k], expanded], 1)
+    assert adjusted_batch["input_ids"].shape[1] == size
+    assert adjusted_batch["attention_mask"].shape[1] == size
+    return adjusted_batch
+
+
+def override_print(enable):
+    import builtins as __builtin__
+
+    builtin_print = __builtin__.print
+
+    def print(*args, **kwargs):
+        force = kwargs.pop("force", False)
+        if force or enable:
+            builtin_print(*args, **kwargs)
+
+    __builtin__.print = print
+
+
+def override_logger(logger, enable):
+    logger_info = logger.info
+
+    def info(*args, **kwargs):
+        force = kwargs.pop("force", False)
+        if force or enable:
+            logger_info(*args, **kwargs)
+
+    logger.info = info
+
+
+def count_hpu_graphs():
+    return len(glob.glob(".graph_dumps/*PreGraph*"))
+
+
+def override_prints(enable, logger):
+    override_print(enable)
+    override_logger(logger, enable)
+
+
+def setup_distributed(args):
+    args.local_rank = int(os.getenv("LOCAL_RANK", "0"))
+    args.world_size = int(os.getenv("WORLD_SIZE", "0"))
+    args.global_rank = int(os.getenv("RANK", "0"))
+
+
+def setup_inference(args, model):
+    import habana_frameworks.torch.core as htcore
+
+    habana_version = get_habana_frameworks_version()
+
+    print("Initializing inference mode")
+    # Keeping the if-else here for back compat. TODO remove later
+    if habana_version.major >= 1 and habana_version.minor >= 16:
+        htcore.hpu_initialize(model, mark_only_scales_as_const=True)
+    else:
+        const_marking = os.getenv("ENABLE_CONST_MARKING", "True")
+        if const_marking == "True":
+            htcore.hpu_initialize(model)
+    return model
+
+
+def setup_const_serialization(const_serialization_path):
+    import uuid
+
+    const_serialization_path = os.path.join(const_serialization_path + uuid.uuid4().hex)
+    os.makedirs(const_serialization_path)
+    from habana_frameworks.torch.hpu import enable_const_section_serialization
+
+    print("Serializing const params to {}".format(const_serialization_path))
+    enable_const_section_serialization(const_serialization_path, True)
+
+
+def setup_env(args):
+    # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
+    check_min_version("4.34.0")
+    check_optimum_habana_min_version("1.9.0.dev0")
+    # TODO: SW-167588 - WA for memory issue in hqt prep_model
+    os.environ.setdefault("EXPERIMENTAL_WEIGHT_SHARING", "FALSE")
+
+    if args.global_rank == 0 and not args.torch_compile and args.show_graphs_count:
+        os.environ.setdefault("GRAPH_VISUALIZATION", "true")
+        shutil.rmtree(".graph_dumps", ignore_errors=True)
+
+    if args.world_size > 0:
+        os.environ.setdefault("PT_HPU_LAZY_ACC_PAR_MODE", "0")
+        os.environ.setdefault("PT_HPU_ENABLE_LAZY_COLLECTIVES", "true")
+
+    if args.use_hpu_graphs and args.limit_hpu_graphs and not args.reuse_cache and args.bucket_internal:
+        # Based upon above conditions and below env variable,
+        # we can call HPU graphs clear_inputs().
+        os.environ.setdefault("PT_HPUGRAPH_DISABLE_TENSOR_CACHE", "1")
+
+    # Tweak generation so that it runs faster on Gaudi
+    from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
+
+    adapt_transformers_to_gaudi()
+
+
+def setup_device(args):
+    if args.device == "hpu":
+        import habana_frameworks.torch.core as htcore
+
+        if args.quant_config or args.load_quantized_model_with_inc or args.local_quantized_inc_model_path:
+            htcore.hpu_set_env()
+    return torch.device(args.device)
+
+
+# patching LinearAllreduce to use ScopedLinearAllReduce
+def patch_scoped_linear_all_reduce(model):
+    from deepspeed.module_inject.layers import LinearAllreduce
+
+    from optimum.habana.transformers.models.modeling_all_models import ScopedLinearAllReduce
+
+    for name, module in model.named_children():
+        if type(module) is LinearAllreduce:
+            SL = ScopedLinearAllReduce(mod=module)
+            setattr(model, name, SL)
+        patch_scoped_linear_all_reduce(module)
+
+
+def get_torch_compiled_model(model, logger):
+    # for gpt_bigcode, mpt, bloom, gpt2 model_type
+    if hasattr(model, "transformer"):
+        model.transformer = torch.compile(
+            model.transformer, backend="hpu_backend", options={"keep_input_mutations": True}
+        )
+    # for gpt_neox
+    elif hasattr(model, "gpt_neox"):
+        model.gpt_neox = torch.compile(model.gpt_neox, backend="hpu_backend", options={"keep_input_mutations": True})
+    # for llama, mistral, mixtral, qwen2
+    elif hasattr(model, "model"):
+        model.model = torch.compile(model.model, backend="hpu_backend", options={"keep_input_mutations": True})
+    else:
+        logger.warning(
+            "In low performance case, please explicitly specify a module you want to wrap with `torch.compile`"
+        )
+        model = torch.compile(model, backend="hpu_backend", options={"keep_input_mutations": True})
+    return model
+
+
+def setup_quantization(model, args):
+    try:
+        from neural_compressor.torch.quantization import FP8Config, convert, prepare
+    except ImportError:
+        raise ImportError(
+            "Module neural_compressor is missing. Please use a newer Synapse version to use quantization."
+        )
+
+    config = FP8Config.from_json_file(args.quant_config)
+    if config.measure:
+        model = prepare(model, config)
+    if config.quantize:
+        model = convert(model, config)
+
+    return model
+
+
+def finalize_quantization(model):
+    try:
+        from neural_compressor.torch.quantization import finalize_calibration
+    except ImportError:
+        raise ImportError(
+            "Module neural_compressor is missing. Please use a newer Synapse version to use quantization."
+        )
+    finalize_calibration(model)
+
+
+def setup_model(args, model_dtype, model_kwargs, logger):
+    logger.info("Single-device run.")
+    print(f"debug=============", model_dtype, flush=True)
+    if args.assistant_model is None:
+        assistant_model = None
+    else:
+        logger.info(f"Using asssitant model {args.assistant_model}.")
+    if args.disk_offload:
+        from accelerate import infer_auto_device_map, init_empty_weights
+
+        config = AutoConfig.from_pretrained(args.model_name_or_path)
+        with init_empty_weights():
+            model = AutoModelForCausalLM.from_config(config)
+        max_memory = {"cpu": "10GiB"}
+        device_map = infer_auto_device_map(model, max_memory=max_memory, dtype=model_dtype)
+        model = AutoModelForCausalLM.from_pretrained(
+            args.model_name_or_path,
+            device_map=device_map,
+            offload_folder="/tmp/offload_folder/",
+            offload_state_dict=True,
+            torch_dtype=model_dtype,
+            **model_kwargs,
+        )
+    elif args.load_quantized_model_with_autogptq:
+        from transformers import GPTQConfig
+
+        quantization_config = GPTQConfig(bits=4, use_exllama=False)
+        model = AutoModelForCausalLM.from_pretrained(
+            args.model_name_or_path, torch_dtype=model_dtype, quantization_config=quantization_config, **model_kwargs
+        )
+    elif args.load_quantized_model_with_autoawq:
+        from transformers import AwqConfig
+
+        quantization_config = AwqConfig(bits=4, version="hpu")
+        model = AutoModelForCausalLM.from_pretrained(
+            args.model_name_or_path, torch_dtype=model_dtype, quantization_config=quantization_config, **model_kwargs
+        )
+    elif args.load_quantized_model_with_inc:
+        # TODO: This will be removed in v1.20 Synapse release
+        # Override neural_compressor split_rank_state_dict for loading neural_magic models on multi-cards.
+        import neural_compressor.torch.algorithms.fp8_quant.save_load as nc_sl
+
+        nc_sl.split_rank_state_dict = local_split_rank_state_dict
+
+        from neural_compressor.torch.quantization import load
+
+        model = load(model_name_or_path=args.model_name_or_path, format="huggingface", device="hpu", **model_kwargs)
+    elif args.local_quantized_inc_model_path:
+        org_model = AutoModelForCausalLM.from_pretrained(
+            args.model_name_or_path,
+            **model_kwargs,
+        )
+
+        from neural_compressor.torch.quantization import load
+
+        model = load(
+            model_name_or_path=args.local_quantized_inc_model_path,
+            format="default",
+            device="hpu",
+            original_model=org_model,
+            **model_kwargs,
+        )
+    else:
+        if args.assistant_model is not None:
+            assistant_model = AutoModelForCausalLM.from_pretrained(
+                args.assistant_model, torch_dtype=model_dtype, **model_kwargs
+            )
+        if args.peft_model is not None:
+            model = peft_model(args, model_dtype, logger, **model_kwargs)
+        else:
+            model = AutoModelForCausalLM.from_pretrained(
+                args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs
+            )
+    if args.quant_config:
+        model = setup_quantization(model, args)
+
+    model = model.eval().to(args.device)
+    if args.assistant_model is not None:
+        assistant_model = assistant_model.eval().to(args.device)
+
+    if args.use_hpu_graphs:
+        from habana_frameworks.torch.hpu import wrap_in_hpu_graph
+
+        from optimum.habana.transformers.trainer import _is_peft_model
+
+        if check_habana_frameworks_version("1.13.0") and model.config.model_type == "falcon":
+            model = wrap_in_hpu_graph(model, hash_with_views=False)
+        else:
+            max_graphs = getattr(args, "max_graphs", None)
+            model = wrap_in_hpu_graph(model, max_graphs=max_graphs)
+        if args.assistant_model is not None:
+            assistant_model = wrap_in_hpu_graph(assistant_model)
+        if _is_peft_model(model):
+            model.base_model = wrap_in_hpu_graph(model.base_model)
+            if model.peft_type == "ADAPTION_PROMPT":
+                model.base_model.model = wrap_in_hpu_graph(model.base_model.model)
+
+    if args.torch_compile:
+        model = get_torch_compiled_model(model, logger)
+        assert "PT_HPU_LAZY_MODE" in os.environ and os.environ["PT_HPU_LAZY_MODE"] == "0", (
+            "Please set PT_HPU_LAZY_MODE=0 on command line when using `--torch_compile`"
+        )
+        # if args.assistant_model is not None:
+        #     assistant_model = get_torch_compiled_model(assistant_model, logger)
+    return model, assistant_model
+
+
+def setup_distributed_model_tp(args, model_dtype, model_kwargs, logger, cache_dir):
+    from typing import Any, MutableMapping
+
+    from optimum.habana.distributed import serialization
+    from optimum.habana.distributed.strategy import TensorParallelStrategy
+
+    logger.info("Multi-device run.")
+
+    assert args.quant_config == "", "Fp8 is not enabled, unset QUANT_CONFIG"
+    assert args.assistant_model is None, "Assistant model must be None"
+
+    from torch import distributed as dist
+
+    if args.device == "hpu":
+        dist.init_process_group(backend="hccl")
+    else:
+        assert False, "Supports TP only on HPU"
+
+    torch._C._distributed_c10d._register_process_group("default", dist.group.WORLD)
+    logger.info("Creating Model")
+    config = AutoConfig.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs)
+    model_kwargs = {}
+    model_kwargs["parallel_strategy"] = TensorParallelStrategy()
+    model = AutoModelForCausalLM.from_config(config, torch_dtype=model_dtype, **model_kwargs)
+
+    initial_device = torch.device("cpu")
+    source = "hf"
+    checkpoint_sharding = None
+    lazy_sd: MutableMapping[str, Any] = {}
+    logger.info("Loading Checkpoints")
+    lazy_sd = serialization.load_state_dict(
+        cache_dir,
+        source=source,
+        distributed_strategy=args.parallel_strategy,
+        checkpoint_sharding=None,
+        initial_device=initial_device,
+        rank=args.global_rank,
+        world_size=args.world_size,
+    )
+    architecture = "llama"
+    if len(lazy_sd):
+        serialization.load_state_dict_into_model(
+            model,
+            lazy_sd,
+            architecture,
+            source,
+            args.parallel_strategy,
+            checkpoint_sharding,
+            initial_device,
+            args.local_rank,
+            args.world_size,
+        )
+
+    model = model.eval().to(args.device)
+
+    if args.use_hpu_graphs:
+        from habana_frameworks.torch.hpu import wrap_in_hpu_graph
+
+        model = wrap_in_hpu_graph(model)
+
+    if args.torch_compile:
+        model = get_torch_compiled_model(model, logger)
+
+    return model, args.assistant_model
+
+
+def setup_distributed_model_ep(args, model_dtype, model_kwargs, logger):
+    logger.info("Multi-device ep run.")
+
+    assert args.quant_config == "", "Fp8 is not enabled, unset QUANT_CONFIG"
+    assert args.assistant_model is None, "Assistant model must be None"
+
+    from torch import distributed as dist
+
+    if args.device == "hpu":
+        dist.init_process_group(backend="hccl")
+    else:
+        assert False, "Supports EP only on HPU"
+
+    torch._C._distributed_c10d._register_process_group("default", dist.group.WORLD)
+    logger.info("Creating Model")
+    config = AutoConfig.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs)
+    config.update({"ep_size": args.world_size})
+
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_name_or_path,
+        config=config,
+        torch_dtype=model_dtype,
+        **model_kwargs,
+    )
+
+    model = model.eval().to(args.device)
+
+    if args.use_hpu_graphs:
+        from habana_frameworks.torch.hpu import wrap_in_hpu_graph
+
+        model = wrap_in_hpu_graph(model)
+
+    if args.torch_compile:
+        model = get_torch_compiled_model(model)
+
+    return model, args.assistant_model
+
+
+def setup_distributed_model(args, model_dtype, model_kwargs, logger):
+    import deepspeed
+
+    logger.info("DeepSpeed is enabled.")
+    deepspeed.init_distributed(dist_backend="hccl")
+    config = AutoConfig.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs)
+
+    keep_module_on_host = False
+    if "Llama-3.1-405B" in args.model_name_or_path:
+        keep_module_on_host = True
+
+    load_to_meta = False if keep_module_on_host else model_on_meta(config)
+
+    if args.assistant_model is None:
+        assistant_model = None
+    else:
+        logger.info(f"Using asssitant model {args.assistant_model}.")
+
+    if load_to_meta:
+        # Construct model with fake meta tensors, later will be replaced on devices during ds-inference ckpt load
+        with deepspeed.OnDevice(dtype=model_dtype, device="meta"):
+            if (
+                hasattr(config, "rope_scaling")
+                and config.rope_scaling
+                and config.rope_scaling["rope_type"] == "llama3"
+                and config.max_position_embeddings > 8192
+            ):
+                config.max_position_embeddings = 8192
+            model = AutoModelForCausalLM.from_config(config, torch_dtype=model_dtype)
+
+        # Model loaded to meta is managed differently
+        checkpoints_json = tempfile.NamedTemporaryFile(suffix=".json", mode="+w")
+
+        # For PEFT models, write the merged model on disk to be able to load it on the meta device
+        if args.peft_model is not None:
+            merged_model_dir = "/tmp/text_generation_merged_peft_model"
+            if args.local_rank == 0:
+                if Path(merged_model_dir).is_dir():
+                    shutil.rmtree(merged_model_dir)
+                peft_model(args, model_dtype, logger, **model_kwargs).save_pretrained(merged_model_dir)
+            torch.distributed.barrier()
+
+        write_checkpoints_json(
+            merged_model_dir if args.peft_model is not None else args.model_name_or_path,
+            args.local_rank,
+            checkpoints_json,
+            token=args.token,
+        )
+    else:
+        # TODO: revisit placement on CPU when auto-injection is possible
+        with deepspeed.OnDevice(dtype=model_dtype, device="cpu"):
+            if args.peft_model is not None:
+                model = peft_model(args, model_dtype, logger, **model_kwargs)
+            else:
+                model = AutoModelForCausalLM.from_pretrained(
+                    args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs
+                )
+    model.eval()
+
+    if args.assistant_model is not None:
+        assistant_model = AutoModelForCausalLM.from_pretrained(
+            args.assistant_model, torch_dtype=model_dtype, **model_kwargs
+        ).eval()
+
+    # Initialize the model
+    ds_inference_kwargs = {"dtype": model_dtype}
+    ds_inference_kwargs["keep_module_on_host"] = keep_module_on_host
+    ds_inference_kwargs["tensor_parallel"] = {"tp_size": args.world_size}
+    ds_inference_kwargs["enable_cuda_graph"] = args.use_hpu_graphs
+    ds_inference_kwargs["injection_policy"] = get_ds_injection_policy(config)
+    if load_to_meta:
+        ds_inference_kwargs["checkpoint"] = checkpoints_json.name
+
+    model = deepspeed.init_inference(model, **ds_inference_kwargs)
+    model = model.module
+    if model.config.model_type in ["llama", "falcon", "qwen2", "starcoder2", "gemma"]:
+        patch_scoped_linear_all_reduce(model)
+
+    if args.quant_config:
+        model = setup_quantization(model, args)
+
+    if args.torch_compile:
+        model = get_torch_compiled_model(model, logger)
+        # if args.assistant_model is not None:
+        #     assistant_model = get_torch_compiled_model(assistant_model, logger)
+    return model, assistant_model
+
+
+def peft_model(args, model_dtype, logger, **model_kwargs):
+    import importlib.util
+
+    if importlib.util.find_spec("peft") is None:
+        raise ImportError("The `peft` package is not installed, please run: `pip install peft`.")
+    from peft import AutoPeftModelForCausalLM
+    from peft.config import PeftConfigMixin
+
+    base_model_name = PeftConfigMixin.from_pretrained(
+        args.peft_model,
+        token=model_kwargs["token"] if "token" in model_kwargs else None,
+    ).base_model_name_or_path
+
+    base_model_is_local = Path(base_model_name).is_dir()
+    if not base_model_is_local:
+        # Check if the base model path to a remote repository on the HF Hub exists
+        from huggingface_hub import list_repo_files
+
+        try:
+            list_repo_files(base_model_name)
+            base_model_is_remote = True
+        except Exception:
+            base_model_is_remote = False
+
+    if base_model_is_local or base_model_is_remote:
+        model = AutoPeftModelForCausalLM.from_pretrained(args.peft_model, torch_dtype=model_dtype, **model_kwargs)
+    else:
+        # Since the base model doesn't exist locally nor remotely, use `args.model_name_or_path` as the base model
+        logger.warning(
+            f"The base model `{base_model_name}` of the LoRA configuration associated"
+            f" to `{args.peft_model}` does not exist locally or remotely. Using "
+            f"`--model_name_or_path {args.model_name_or_path}` as a fall back for the base model."
+        )
+        from peft import PeftModel
+
+        model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, torch_dtype=model_dtype, **model_kwargs)
+        model = PeftModel.from_pretrained(model, args.peft_model, torch_dtype=model_dtype, **model_kwargs)
+    if hasattr(model, "merge_and_unload"):
+        model = model.merge_and_unload()
+        if model_dtype == torch.bfloat16:
+            model = model.to(torch.bfloat16)
+        return model
+    else:
+        from optimum.habana.peft.peft_model import gaudi_generate, gaudi_prepare_inputs_for_generation
+
+        model.__class__.generate = gaudi_generate
+        model.__class__.prepare_inputs_for_generation = gaudi_prepare_inputs_for_generation
+        if model.peft_type == "ADAPTION_PROMPT":
+            from peft import tuners
+
+            from optimum.habana.peft.layer import (
+                GaudiAdaptedAttention_getattr,
+                GaudiAdaptedAttentionPreAttnForward,
+            )
+
+            tuners.adaption_prompt.layer.AdaptedAttention.pre_attn_forward = GaudiAdaptedAttentionPreAttnForward
+            tuners.adaption_prompt.layer.AdaptedAttention.__getattr__ = GaudiAdaptedAttention_getattr
+
+        return model
+
+
+def setup_tokenizer(args, model, assistant_model, logger):
+    tokenizer_kwargs = {
+        "revision": args.model_revision,
+        "token": args.token,
+        "trust_remote_code": args.trust_remote_code,
+    }
+    if args.bad_words is not None or args.force_words is not None:
+        tokenizer_kwargs["add_prefix_space"] = True
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, **tokenizer_kwargs)
+    if not model.config.is_encoder_decoder:
+        tokenizer.padding_side = "left"
+
+    if model.config.model_type == "llama":
+        if model.generation_config.pad_token_id is None:
+            if isinstance(model.generation_config.eos_token_id, int):
+                model.generation_config.pad_token_id = model.generation_config.eos_token_id
+            elif isinstance(model.generation_config.eos_token_id, list):
+                model.generation_config.pad_token_id = model.generation_config.eos_token_id[0]
+        if assistant_model is not None:
+            if assistant_model.generation_config.pad_token_id is None:
+                if isinstance(assistant_model.generation_config.eos_token_id, int):
+                    assistant_model.generation_config.pad_token_id = assistant_model.generation_config.eos_token_id
+                elif isinstance(assistant_model.generation_config.eos_token_id, list):
+                    assistant_model.generation_config.pad_token_id = assistant_model.generation_config.eos_token_id[0]
+        tokenizer.bos_token_id = model.generation_config.bos_token_id
+        if isinstance(model.generation_config.eos_token_id, int):
+            tokenizer.eos_token_id = model.generation_config.eos_token_id
+        elif isinstance(model.generation_config.eos_token_id, list):
+            tokenizer.eos_token_id = model.generation_config.eos_token_id[0]
+        tokenizer.pad_token_id = model.generation_config.pad_token_id
+        tokenizer.pad_token = tokenizer.decode(tokenizer.pad_token_id)
+        tokenizer.eos_token = tokenizer.decode(tokenizer.eos_token_id)
+        tokenizer.bos_token = tokenizer.decode(tokenizer.bos_token_id)
+    if model.config.model_type == "persimmon":
+        model.generation_config.pad_token_id = model.generation_config.eos_token_id
+        if assistant_model is not None:
+            assistant_model.generation_config.pad_token_id = assistant_model.generation_config.eos_token_id
+        tokenizer.bos_token_id = model.generation_config.bos_token_id
+        tokenizer.eos_token_id = model.generation_config.eos_token_id
+        tokenizer.pad_token_id = model.generation_config.pad_token_id
+        tokenizer.pad_token = tokenizer.decode(tokenizer.pad_token_id)
+        tokenizer.eos_token = tokenizer.decode(tokenizer.eos_token_id)
+        tokenizer.bos_token = tokenizer.decode(tokenizer.bos_token_id)
+
+    # HACK: MiniCPM3 does not support list EOS token ID generation config.
+    if model.config.model_type == "minicpm3" and isinstance(model.generation_config.eos_token_id, list):
+        logger.warning(
+            f"Model type {model.config.model_type} does not support list style EOS token ID in generation config. Only last eos token id will be used."
+        )
+        model.generation_config.eos_token_id = model.generation_config.eos_token_id[-1]
+
+    if model.config.model_type == "mpt":
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        if model.generation_config.pad_token_id is None:
+            model.generation_config.pad_token_id = tokenizer.eos_token_id
+
+    # Some models like GPT2 do not have a PAD token so we have to set it if necessary
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+        model.generation_config.pad_token_id = model.generation_config.eos_token_id
+        if assistant_model is not None:
+            assistant_model.generation_config.pad_token_id = assistant_model.generation_config.eos_token_id
+
+    return tokenizer, model, assistant_model
+
+
+def setup_generation_config(args, model, assistant_model, tokenizer):
+    bad_words_ids = None
+    force_words_ids = None
+    if args.bad_words is not None:
+        bad_words_ids = [tokenizer.encode(bad_word, add_special_tokens=False) for bad_word in args.bad_words]
+    if args.force_words is not None:
+        force_words_ids = [tokenizer.encode(force_word, add_special_tokens=False) for force_word in args.force_words]
+
+    is_optimized = model_is_optimized(model.config)
+
+    # Generation configuration
+    generation_config = copy.deepcopy(model.generation_config)
+    generation_config.max_new_tokens = args.max_new_tokens
+    generation_config.use_cache = args.use_kv_cache
+    generation_config.static_shapes = is_optimized and assistant_model is None
+    generation_config.bucket_size = args.bucket_size if is_optimized else -1
+    generation_config.bucket_internal = args.bucket_internal
+    generation_config.do_sample = args.do_sample
+    generation_config.num_beams = args.num_beams
+    generation_config.top_k = args.top_k
+    generation_config.penalty_alpha = args.penalty_alpha
+    generation_config.bad_words_ids = bad_words_ids
+    generation_config.force_words_ids = force_words_ids
+    generation_config.num_return_sequences = args.num_return_sequences
+    generation_config.trim_logits = args.trim_logits
+    generation_config.attn_softmax_bf16 = args.attn_softmax_bf16
+    generation_config.limit_hpu_graphs = args.limit_hpu_graphs
+    generation_config.clear_hpu_graphs_cache = args.clear_hpu_graphs_cache
+    generation_config.reuse_cache = args.reuse_cache
+    generation_config.reduce_recompile = args.reduce_recompile
+    if generation_config.reduce_recompile:
+        assert generation_config.bucket_size > 0
+    generation_config.use_flash_attention = args.use_flash_attention
+    generation_config.flash_attention_recompute = args.flash_attention_recompute
+    generation_config.flash_attention_causal_mask = args.flash_attention_causal_mask
+    generation_config.flash_attention_fast_softmax = args.flash_attention_fast_softmax
+    generation_config.trust_remote_code = args.trust_remote_code
+    generation_config.valid_sequence_lengths = None
+    generation_config.attn_batch_split = args.attn_batch_split
+
+    return generation_config
+
+
+def exclude_hpu_graph_configs(args):
+    # Excluded configs for batch size 1 for hpu graph
+    if args.batch_size == 1 and args.limit_hpu_graphs:
+        if "falcon-180B" in args.model_name_or_path or "falcon-180b" in args.model_name_or_path:
+            return False
+        if args.world_size == 2 or args.world_size == 4 or args.world_size == 8:
+            if args.quant_config or args.load_quantized_model_with_inc or args.local_quantized_inc_model_path:
+                if args.max_input_tokens >= 8192 and args.max_new_tokens >= 128:
+                    return False
+            else:
+                if args.max_input_tokens >= 4096 and args.max_new_tokens >= 128:
+                    return False
+        return True
+    else:
+        return False
+
+
+def initialize_model(args, logger):
+    init_start = time.perf_counter()
+    setup_distributed(args)
+    if not args.world_size > 0 and args.attn_batch_split > 1:
+        logger.warning("Disabling attention batch splitting as it's unnecessary for single-card execution")
+        args.attn_batch_split = 1
+    if exclude_hpu_graph_configs(args):
+        args.limit_hpu_graphs = False
+    override_prints(args.global_rank == 0 or args.verbose_workers, logger)
+    setup_env(args)
+    setup_device(args)
+    set_seed(args.seed)
+    cache_dir = get_repo_root(args.model_name_or_path, local_rank=args.local_rank, token=args.token)
+    if args.assistant_model is not None:
+        get_repo_root(args.assistant_model, local_rank=args.local_rank, token=args.token)
+    use_deepspeed = args.world_size > 0
+    if use_deepspeed or args.bf16:
+        model_dtype = torch.bfloat16
+    else:
+        model_dtype = torch.float
+        args.attn_softmax_bf16 = False
+    print(f"debug=============", model_dtype, flush=True)
+    model_kwargs = {
+        "revision": args.model_revision,
+        "token": args.token,
+        "trust_remote_code": args.trust_remote_code,
+    }
+    if args.load_quantized_model_with_inc or args.local_quantized_inc_model_path:
+        model_kwargs["torch_dtype"] = torch.bfloat16
+
+    if args.trust_remote_code:
+        logger.warning("`trust_remote_code` is set, there is no guarantee this model works properly and it may fail")
+
+    model, assistant_model = (
+        setup_model(args, model_dtype, model_kwargs, logger)
+        if not use_deepspeed or args.load_quantized_model_with_inc
+        else setup_distributed_model(args, model_dtype, model_kwargs, logger)
+        if args.parallel_strategy == "none"
+        else setup_distributed_model_tp(args, model_dtype, model_kwargs, logger, cache_dir)
+        if args.parallel_strategy == "tp"
+        else setup_distributed_model_ep(args, model_dtype, model_kwargs, logger)
+    )
+
+    tokenizer, model, assistant_model = setup_tokenizer(args, model, assistant_model, logger)
+    generation_config = setup_generation_config(args, model, assistant_model, tokenizer)
+
+    if args.const_serialization_path:
+        setup_const_serialization(args.const_serialization_path)
+    if args.quant_config or args.load_quantized_model_with_inc or args.local_quantized_inc_model_path:
+        model = setup_inference(args, model)
+    init_end = time.perf_counter()
+    logger.info(f"Args: {args}")
+    logger.info(f"device: {args.device}, n_hpu: {args.world_size}, bf16: {model_dtype == torch.bfloat16}")
+    logger.info(f"Model initialization took {(init_end - init_start):.3f}s")
+    return model, assistant_model, tokenizer, generation_config
+
+
+def save_model(model, tokenizer, save_path):
+    """Saves the model and tokenizer in the huggingface format with neural_compressor."""
+    from neural_compressor.torch.quantization import save
+
+    save(model, save_path, format="huggingface")
+    tokenizer.save_pretrained(save_path)
+
+
+# TODO: This will be removed in v1.20 Synapse release
+# Override neural_compressor split_rank_state_dict for loading neural_magic models on multi-cards.
+def local_split_rank_state_dict(model, gathered_state_dict):
+    """split state_dict for current local_rank."""
+    from neural_compressor.torch.algorithms.fp8_quant.save_load import (
+        cur_accelerator,
+        local_rank,
+        split_weights,
+        world_size,
+    )
+
+    rank_state_dict = {}
+    for name, param in model.named_parameters():
+        if name in gathered_state_dict:
+            full_weight = gathered_state_dict[name]
+            if len(param.shape) != 0 and full_weight.shape != param.shape:
+                if full_weight.shape[0] != param.shape[0]:
+                    split_weight = split_weights(full_weight, world_size, local_rank, split_axis=0).clone()
+                elif full_weight.shape[1] != param.shape[1]:
+                    split_weight = split_weights(full_weight, world_size, local_rank, split_axis=1).clone()
+                else:
+                    split_weight = split_weights(full_weight, world_size, local_rank, split_axis=0).clone()
+            else:
+                split_weight = full_weight
+            rank_state_dict[name] = split_weight
+        cur_accelerator.synchronize()
+
+    return rank_state_dict
+

--- a/PyTorch/triton_inference_server/qwen2/config.pbtxt
+++ b/PyTorch/triton_inference_server/qwen2/config.pbtxt
@@ -1,0 +1,20 @@
+name: "qwen2"
+backend: "python"
+
+input [
+  {
+    name: "INPUT0"
+    data_type: TYPE_STRING
+    dims: [ -1 ]
+  }
+]
+
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_STRING
+    dims: [ -1 ]
+  }
+]
+instance_group [{ kind: KIND_CPU }]
+


### PR DESCRIPTION
# Summary
This PR adds tutorials for Triton Inference Server on Gaudi

## Details
The toturial is based on: 
- [Habana Doc on TIS](https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Triton_Inference.html)
- [Upstream TIS HF model deployment](https://github.com/triton-inference-server/tutorials/blob/17331012af74eab68ad7c86d8a4ae494272ca4f7/Quick_Deploy/HuggingFaceTransformers/README.md)

> [!NOTE]
> As of date this PR is opened, the Habana Doc document on TIS is buggy, outdated and incomplete. The steps in this PR remediates that. 

## Tests
All of the steps have been fully tested on Gaudi2 servers.  