### PR TITLE
Fix pip command

### DIFF
--- a/PyTorch/vLLM_Tutorials/FP8_Quantization_using_INC/FP8_Quantization_using_INC.ipynb
+++ b/PyTorch/vLLM_Tutorials/FP8_Quantization_using_INC/FP8_Quantization_using_INC.ipynb
@@ -147,7 +147,7 @@
     "cd /root\n",
     "git clone https://github.com/HabanaAI/vllm-fork.git -b v0.7.2+Gaudi-1.21.0 \n",
     "cd vllm-fork\n",
-    "pip install -r --quiet requirements-hpu.txt\n",
+    "pip install --quiet -r requirements-hpu.txt\n",
     "python3 setup.py develop\n",
     "pip install datasets"
    ]


### PR DESCRIPTION
PyTorch/vLLM_Tutorials/FP8_Quantization_using_INC/FP8_Quantization_using_INC.ipynb notebook has:
```
pip install -r --quiet requirements-hpu.txt
```

This is incorrect as the -r expects the requirements file.
```
ERROR: Could not open requirements file: [Errno 2] No such file or directory: '--quiet'
```

This PR fixes the order of arguments.